### PR TITLE
PathfindInGame benchmark — reconcile to MUO main (#2478) + PR-6 work

### DIFF
--- a/Benchmarks/PathfindInGame/BenchmarkFixture.cs
+++ b/Benchmarks/PathfindInGame/BenchmarkFixture.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Server;
+using Server.Engines.Pathing.Cache;
+using Server.Items;
+using Server.Misc;
+using Server.Mobiles;
+using Server.Movement;
+using Server.Tests.Maps;
+
+namespace PathfindInGame;
+
+public static class BenchmarkFixture
+{
+    private static bool _initialized;
+
+    public static void EnsureInitialized()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        Core.ApplicationAssembly = Assembly.GetExecutingAssembly();
+        Core.LoopContext = new EventLoopContext();
+        Core.Expansion = Expansion.EJ;
+
+        ServerConfiguration.Load(true);
+        ServerConfiguration.AssemblyDirectories.Add(Core.BaseDirectory);
+
+        // Wire the local UO client data files (env var override or fallback).
+        var clientFiles = Environment.GetEnvironmentVariable("MODERNUO_TEST_DATA_DIR")
+                          ?? @"C:\Ultima Online Classic";
+        ServerConfiguration.DataDirectories.Add(clientFiles);
+
+        AssemblyHandler.LoadAssemblies(["Server.dll", "UOContent.dll"]);
+
+        NPCSpeeds.Configure();
+        SkillsInfo.Configure();
+        Server.Network.NetState.Configure();
+        TestMapDefinitions.ConfigureTestMapDefinitions();
+
+        World.Configure();
+        Timer.Init(0);
+        RaceDefinitions.Configure();
+        MovementImpl.Configure();
+        World.Load();
+        World.ExitSerializationThreads();
+        DecayScheduler.Configure();
+
+        // CRITICAL: TileData's static cctor short-circuits when running outside the live
+        // server (Server/TileData.cs ~line 295). Force-load via reflection so
+        // LandTable / ItemTable flags populate; otherwise every tile reads as flag=None
+        // and the algorithm treats everything as walkable (meaningless 86ns paths).
+        ForceLoadTileData();
+
+        EnsureBakedFiles();
+
+        _initialized = true;
+    }
+
+    /// <summary>
+    /// Make sure each map referenced by the bench corpus has a fresh, valid
+    /// &lt;mapId&gt;.swb file before the harness starts measuring. Calls
+    /// <see cref="StepCache.BakeMap"/> in-process if the file is missing or has
+    /// a stale Fingerprint. Single source of truth — no separate bake program.
+    /// </summary>
+    private static void EnsureBakedFiles()
+    {
+        var dir = ResolvePathfindingDataDir();
+        Directory.CreateDirectory(dir);
+
+        // Bench corpus is currently Trammel-only; expand the set as new map scenarios land.
+        var mapsToBake = new HashSet<int> { 1 };
+
+        foreach (var mapId in mapsToBake)
+        {
+            var path = Path.Combine(dir, $"{mapId}.swb");
+            var liveFingerprint = StepCache.ComputeLiveFingerprint(mapId);
+            if (StepCache.TryReadFingerprintFromFile(path, out var existingFingerprint)
+                && existingFingerprint == liveFingerprint)
+            {
+                continue;
+            }
+
+            Console.Error.WriteLine($"[BenchmarkFixture] Baking step cache for map {mapId} → {path}");
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var written = StepCache.Instance.BakeMap(mapId, path);
+            sw.Stop();
+            Console.Error.WriteLine(
+                $"[BenchmarkFixture] Bake complete in {sw.Elapsed.TotalSeconds:F2}s ({written} chunks)"
+            );
+
+            // Drop the chunks BakeMap left resident so the bench iterations start from
+            // a known cold state. The .swb file is now on disk; lazy readers in the
+            // harness's GlobalSetup will open it.
+            StepCache.Instance.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Resolves the directory containing &lt;mapId&gt;.swb files. Honors
+    /// <c>MODERNUO_PATHFINDING_DATA_DIR</c>; otherwise walks upward from
+    /// <see cref="AppContext.BaseDirectory"/> looking for
+    /// <c>ModernUO/Distribution/Data/Pathfinding/</c>. Public so the harness can
+    /// reuse it when registering lazy readers.
+    /// </summary>
+    public static string ResolvePathfindingDataDir()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable("MODERNUO_PATHFINDING_DATA_DIR");
+        if (!string.IsNullOrEmpty(fromEnv))
+        {
+            return fromEnv;
+        }
+
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 12 && current is not null; i++)
+        {
+            var candidate = Path.Combine(current.FullName, "ModernUO", "Distribution", "Data", "Pathfinding");
+            if (Directory.Exists(Path.GetDirectoryName(candidate)!))
+            {
+                return candidate;
+            }
+            current = current.Parent;
+        }
+
+        return Path.Combine(AppContext.BaseDirectory, "Pathfinding");
+    }
+
+    private static void ForceLoadTileData()
+    {
+        var loadMethod = typeof(TileData).GetMethod(
+            "Load",
+            BindingFlags.Static | BindingFlags.NonPublic
+        );
+        if (loadMethod == null)
+        {
+            throw new InvalidOperationException(
+                "TileData.Load not found via reflection — engine may have refactored."
+            );
+        }
+        loadMethod.Invoke(null, null);
+    }
+}

--- a/Benchmarks/PathfindInGame/BenchmarkFixture.cs
+++ b/Benchmarks/PathfindInGame/BenchmarkFixture.cs
@@ -64,9 +64,19 @@ public static class BenchmarkFixture
     /// <summary>
     /// Make sure each map referenced by the bench corpus has a fresh, valid
     /// &lt;mapId&gt;.swb file before the harness starts measuring. Calls
-    /// <see cref="StepCache.BakeMap"/> in-process if the file is missing or has
-    /// a stale Fingerprint. Single source of truth — no separate bake program.
+    /// <see cref="StepCache.BakeMap"/> in-process if the file is missing or stale.
+    /// Single source of truth — no separate bake program.
     /// </summary>
+    /// <remarks>
+    /// Freshness is decided by trying to open the file: <see cref="StepCache.TryOpenLazyReader"/>
+    /// goes through <c>StepCacheFile.OpenForLazy</c>, which validates the embedded TileData
+    /// fingerprint and rejects a missing / stale / malformed file (returns false). So "can we
+    /// open it?" IS the freshness check — there is no separate fingerprint compare (the old
+    /// <c>ComputeLiveFingerprint</c>/<c>TryReadFingerprintFromFile</c> pair was removed by the
+    /// file-fingerprint rework in #2478). Mirrors the live boot path
+    /// (<c>PathCacheCommands.Initialize</c>: <c>HasLazyReader</c> else <c>BakeMap</c> then
+    /// <c>AutoLoadAtStartup</c>).
+    /// </remarks>
     private static void EnsureBakedFiles()
     {
         var dir = ResolvePathfindingDataDir();
@@ -78,9 +88,9 @@ public static class BenchmarkFixture
         foreach (var mapId in mapsToBake)
         {
             var path = Path.Combine(dir, $"{mapId}.swb");
-            var liveFingerprint = StepCache.ComputeLiveFingerprint(mapId);
-            if (StepCache.TryReadFingerprintFromFile(path, out var existingFingerprint)
-                && existingFingerprint == liveFingerprint)
+
+            // A fingerprint-valid file opens cleanly → nothing to bake.
+            if (StepCache.Instance.TryOpenLazyReader(path, mapId))
             {
                 continue;
             }
@@ -93,11 +103,12 @@ public static class BenchmarkFixture
                 $"[BenchmarkFixture] Bake complete in {sw.Elapsed.TotalSeconds:F2}s ({written} chunks)"
             );
 
-            // Drop the chunks BakeMap left resident so the bench iterations start from
-            // a known cold state. The .swb file is now on disk; lazy readers in the
-            // harness's GlobalSetup will open it.
-            StepCache.Instance.Clear();
+            StepCache.Instance.ClearResidentChunks();
         }
+
+        // Leave a clean slate: drop resident chunks and close the freshness-probe readers.
+        // The harness's GlobalSetup opens its own lazy readers per provider.
+        StepCache.Instance.Clear();
     }
 
     /// <summary>

--- a/Benchmarks/PathfindInGame/CacheOffBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/CacheOffBenchmarks.cs
@@ -1,0 +1,98 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Server;
+using Server.Engines.Pathing.Cache;
+using Server.PathAlgorithms;
+using Server.PathAlgorithms.FastAStar;
+using Server.Systems.FeatureFlags;
+
+namespace PathfindInGame;
+
+/// <summary>
+/// Proves the "cache OFF == no regression vs the removed FastAStar" claim for RAM-starved /
+/// crappy-hardware shards.
+///
+/// With <see cref="ContentFeatureFlags.BitmapPathfindingCache"/> = false,
+/// <see cref="BitmapAStarAlgorithm"/> routes every cell expansion straight to its per-cell
+/// slow path (<c>GetSuccessorsSlowPath</c> → <c>MovementImpl.CheckMovement</c>) with NO cache
+/// probe and NO chunk building — the same per-cell work the old FastAStar did. A shard that
+/// disables the cache pays zero warming memory; this bench shows it also pays ~1x, not a
+/// regression.
+///
+/// Runs BitmapAStar (cache forced OFF) head-to-head against the vendored FastAStar baseline
+/// over the same corpus. Expect ratio ≈ 1.0 across scenarios, zero allocations for both.
+///
+/// REQUIRES the ModernUO submodule to expose ContentFeatureFlags.BitmapPathfindingCache
+/// (present on the pathfinding branch). Run:
+///   dotnet run -c Release -- --filter '*CacheOffBenchmarks*'
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class CacheOffBenchmarks
+{
+    private static readonly PathfindScenario[] _scenarios = LoadCorpus();
+    private StubCreature[] _stubs = null!;
+    private bool _prevFlag;
+
+    private static PathfindScenario[] LoadCorpus()
+    {
+        var corpusPath = Path.Combine(AppContext.BaseDirectory, "Corpus", "baseline.jsonl");
+        return ScenarioCorpus.LoadJsonl(corpusPath);
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        BenchmarkFixture.EnsureInitialized();
+
+        _prevFlag = ContentFeatureFlags.BitmapPathfindingCache;
+        ContentFeatureFlags.BitmapPathfindingCache = false; // force pure slow path, no cache
+
+        _stubs = new StubCreature[_scenarios.Length];
+        for (var i = 0; i < _scenarios.Length; i++)
+        {
+            var s = _scenarios[i];
+            var stub = new StubCreature { CanSwim = s.CanSwim, CantWalk = false };
+            stub.SetMobilityFlags(s.CanOpenDoors, s.CanMoveOverObstacles);
+            stub.MoveToWorld(s.Start, s.ResolveMap());
+            _stubs[i] = stub;
+        }
+
+        // No cache state should matter with the flag off; drop any residents/readers so the
+        // measurement is unambiguously the slow path.
+        StepCache.Instance.CloseLazyReaders();
+        StepCache.Instance.ClearResidentChunks();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => ContentFeatureFlags.BitmapPathfindingCache = _prevFlag;
+
+    public IEnumerable<int> ScenarioIndices()
+    {
+        for (var i = 0; i < _scenarios.Length; i++)
+        {
+            yield return i;
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    [ArgumentsSource(nameof(ScenarioIndices))]
+    public Direction[]? FastAStar_Find(int scenarioIndex)
+    {
+        var s = _scenarios[scenarioIndex];
+        return FastAStarAlgorithm.Instance.Find(_stubs[scenarioIndex], s.ResolveMap(), s.Start, s.Goal);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(ScenarioIndices))]
+    public Direction[]? BitmapAStar_CacheOff_Find(int scenarioIndex)
+    {
+        var s = _scenarios[scenarioIndex];
+        return BitmapAStarAlgorithm.Instance.Find(_stubs[scenarioIndex], s.ResolveMap(), s.Start, s.Goal);
+    }
+}

--- a/Benchmarks/PathfindInGame/Corpus/baseline.jsonl
+++ b/Benchmarks/PathfindInGame/Corpus/baseline.jsonl
@@ -8,3 +8,4 @@
 {"Name":"trammel_combat_adjust_3tile","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1499,"GoalY":1631,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
 {"Name":"trammel_npc_perception_5tile","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1501,"GoalY":1632,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
 {"Name":"trammel_npc_patrol_8tile","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1504,"GoalY":1628,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_britain_harbor_inlet_swim","MapId":1,"StartX":1408,"StartY":1770,"StartZ":-5,"GoalX":1414,"GoalY":1764,"GoalZ":-5,"CanSwim":true,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}

--- a/Benchmarks/PathfindInGame/Corpus/baseline.jsonl
+++ b/Benchmarks/PathfindInGame/Corpus/baseline.jsonl
@@ -4,3 +4,7 @@
 {"Name":"trammel_multifloor_brit_inn","MapId":1,"StartX":1494,"StartY":1626,"StartZ":20,"GoalX":1502,"GoalY":1632,"GoalZ":20,"CanSwim":false,"CanFly":false,"CanOpenDoors":true,"CanMoveOverObstacles":false}
 {"Name":"trammel_britain_causeway","MapId":1,"StartX":1478,"StartY":1647,"StartZ":0,"GoalX":1502,"GoalY":1647,"GoalZ":0,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
 {"Name":"trammel_deep_sea_serpent_open_ocean","MapId":1,"StartX":2368,"StartY":2799,"StartZ":-5,"GoalX":2400,"GoalY":2799,"GoalZ":-5,"CanSwim":true,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_pet_follow_2tile","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1498,"GoalY":1629,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_combat_adjust_3tile","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1499,"GoalY":1631,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_npc_perception_5tile","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1501,"GoalY":1632,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_npc_patrol_8tile","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1504,"GoalY":1628,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}

--- a/Benchmarks/PathfindInGame/Corpus/baseline.jsonl
+++ b/Benchmarks/PathfindInGame/Corpus/baseline.jsonl
@@ -1,8 +1,8 @@
-{"Name":"trammel_open_plain","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1530,"GoalY":1660,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
-{"Name":"trammel_dense_forest_yew","MapId":1,"StartX":585,"StartY":845,"StartZ":0,"GoalX":615,"GoalY":875,"GoalZ":0,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
-{"Name":"trammel_corridor_brit_sewer","MapId":1,"StartX":1418,"StartY":1696,"StartZ":-32,"GoalX":1450,"GoalY":1720,"GoalZ":-32,"CanSwim":false,"CanFly":false,"CanOpenDoors":true,"CanMoveOverObstacles":false}
-{"Name":"trammel_multifloor_brit_inn","MapId":1,"StartX":1494,"StartY":1626,"StartZ":20,"GoalX":1502,"GoalY":1632,"GoalZ":20,"CanSwim":false,"CanFly":false,"CanOpenDoors":true,"CanMoveOverObstacles":false}
-{"Name":"trammel_britain_causeway","MapId":1,"StartX":1478,"StartY":1647,"StartZ":0,"GoalX":1502,"GoalY":1647,"GoalZ":0,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_open_plain","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1514,"GoalY":1628,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_brit_sewer_walkway","MapId":1,"StartX":6034,"StartY":1479,"StartZ":5,"GoalX":6045,"GoalY":1471,"GoalZ":5,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_dense_forest","MapId":1,"StartX":1521,"StartY":912,"StartZ":0,"GoalX":1521,"GoalY":936,"GoalZ":0,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_building_second_floor","MapId":1,"StartX":1494,"StartY":1622,"StartZ":40,"GoalX":1502,"GoalY":1622,"GoalZ":40,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_britain_causeway","MapId":1,"StartX":1488,"StartY":1641,"StartZ":40,"GoalX":1475,"GoalY":1641,"GoalZ":40,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
 {"Name":"trammel_deep_sea_serpent_open_ocean","MapId":1,"StartX":2368,"StartY":2799,"StartZ":-5,"GoalX":2400,"GoalY":2799,"GoalZ":-5,"CanSwim":true,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
 {"Name":"trammel_pet_follow_2tile","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1498,"GoalY":1629,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
 {"Name":"trammel_combat_adjust_3tile","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1499,"GoalY":1631,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}

--- a/Benchmarks/PathfindInGame/Corpus/baseline.jsonl
+++ b/Benchmarks/PathfindInGame/Corpus/baseline.jsonl
@@ -1,0 +1,6 @@
+{"Name":"trammel_open_plain","MapId":1,"StartX":1496,"StartY":1628,"StartZ":10,"GoalX":1530,"GoalY":1660,"GoalZ":10,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_dense_forest_yew","MapId":1,"StartX":585,"StartY":845,"StartZ":0,"GoalX":615,"GoalY":875,"GoalZ":0,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_corridor_brit_sewer","MapId":1,"StartX":1418,"StartY":1696,"StartZ":-32,"GoalX":1450,"GoalY":1720,"GoalZ":-32,"CanSwim":false,"CanFly":false,"CanOpenDoors":true,"CanMoveOverObstacles":false}
+{"Name":"trammel_multifloor_brit_inn","MapId":1,"StartX":1494,"StartY":1626,"StartZ":20,"GoalX":1502,"GoalY":1632,"GoalZ":20,"CanSwim":false,"CanFly":false,"CanOpenDoors":true,"CanMoveOverObstacles":false}
+{"Name":"trammel_britain_causeway","MapId":1,"StartX":1478,"StartY":1647,"StartZ":0,"GoalX":1502,"GoalY":1647,"GoalZ":0,"CanSwim":false,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}
+{"Name":"trammel_deep_sea_serpent_open_ocean","MapId":1,"StartX":2368,"StartY":2799,"StartZ":-5,"GoalX":2400,"GoalY":2799,"GoalZ":-5,"CanSwim":true,"CanFly":false,"CanOpenDoors":false,"CanMoveOverObstacles":false}

--- a/Benchmarks/PathfindInGame/FastAStarAlgorithm.cs
+++ b/Benchmarks/PathfindInGame/FastAStarAlgorithm.cs
@@ -1,0 +1,297 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2026 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: FastAStarAlgorithm.cs                                           *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.  *
+ ************************************************************************/
+
+using System;
+using Server.Mobiles;
+using CalcMoves = Server.Movement.Movement;
+using MoveImpl = Server.Movement.MovementImpl;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Server.PathAlgorithms.FastAStar;
+
+public class FastAStarAlgorithm : PathAlgorithm
+{
+    private struct PathNode
+    {
+        public int cost;
+        public int total;
+        public int parent;
+        public int z;
+    }
+
+    private const int MaxDepth = 300;
+    private const int AreaSize = 38;
+
+    private const int NodeCount = AreaSize * AreaSize * PlaneCount;
+
+    private const int PlaneOffset = 128;
+    private const int PlaneCount = 13;
+    private const int PlaneHeight = 20;
+    public static readonly PathAlgorithm Instance = new FastAStarAlgorithm();
+
+    private static readonly Direction[] _path = new Direction[AreaSize * AreaSize];
+    private static readonly PathNode[] _nodes = new PathNode[NodeCount];
+    private static readonly byte[] _nodeStates = new byte[NodeCount];
+    private static readonly int[] _successors = new int[8];
+    private static readonly PriorityQueue<int, int> _openQueue = new();
+
+    private static int _xOffset;
+    private static int _yOffset;
+
+    private Point3D _goal;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Heuristic(int x, int y, int z)
+    {
+        x -= _goal.X - _xOffset;
+        y -= _goal.Y - _yOffset;
+        z -= _goal.Z;
+
+        x *= 11;
+        y *= 11;
+
+        return x * x + y * y + z * z;
+    }
+
+    public override bool CheckCondition(Mobile m, Map map, Point3D start, Point3D goal) =>
+        Utility.InRange(start, goal, AreaSize);
+
+    public override Direction[] Find(Mobile m, Map map, Point3D start, Point3D goal)
+    {
+        if (!Utility.InRange(start, goal, AreaSize))
+        {
+            return null;
+        }
+
+        Array.Clear(_nodeStates);
+
+        _goal = goal;
+
+        _xOffset = (start.X + goal.X - AreaSize) / 2;
+        _yOffset = (start.Y + goal.Y - AreaSize) / 2;
+
+        var fromNode = GetIndex(start.X, start.Y, start.Z);
+        var destNode = GetIndex(goal.X, goal.Y, goal.Z);
+
+        _nodes[fromNode].cost = 0;
+        _nodes[fromNode].total = Heuristic(start.X - _xOffset, start.Y - _yOffset, start.Z);
+        _nodes[fromNode].parent = -1;
+        _nodes[fromNode].z = start.Z;
+
+        _openQueue.Enqueue(fromNode, _nodes[fromNode].total);
+        _nodeStates[fromNode] = 1;
+
+        var bc = m as BaseCreature;
+
+        int backtrack = 0, depth = 0;
+
+        var path = _path;
+
+        while (_openQueue.Count > 0)
+        {
+            if (++depth > MaxDepth)
+            {
+                break;
+            }
+
+            if (!_openQueue.TryDequeue(out var bestNode, out var bestTotal))
+            {
+                break;
+            }
+
+            // Duplicate, lower priority
+            if (_nodeStates[bestNode] == 2 || _nodes[bestNode].total != bestTotal)
+            {
+                continue;
+            }
+
+            _nodeStates[bestNode] = 2;
+
+            if (bc != null)
+            {
+                MoveImpl.AlwaysIgnoreDoors = bc.CanOpenDoors;
+                MoveImpl.IgnoreMovableImpassables = bc.CanMoveOverObstacles;
+            }
+
+            MoveImpl.Goal = goal;
+
+            var vals = _successors;
+            var count = GetSuccessors(bestNode, m, map);
+
+            MoveImpl.AlwaysIgnoreDoors = false;
+            MoveImpl.IgnoreMovableImpassables = false;
+            MoveImpl.Goal = Point3D.Zero;
+
+            if (count == 0)
+            {
+                continue;
+            }
+
+            for (var i = 0; i < count; ++i)
+            {
+                var newNode = vals[i];
+
+                // Skip if the node is already closed
+                if (_nodeStates[newNode] == 2)
+                {
+                    continue;
+                }
+
+                var isDiagonal = i % 2 == 1;
+                var moveCost = isDiagonal ? 14 : 10;
+                var newCost = _nodes[bestNode].cost + moveCost;
+                var newTotal = newCost + Heuristic(
+                    newNode % AreaSize,
+                    newNode / AreaSize % AreaSize,
+                    _nodes[newNode].z
+                );
+
+                if (_nodeStates[newNode] == 0 || newTotal < _nodes[newNode].total)
+                {
+                    _nodes[newNode].parent = bestNode;
+                    _nodes[newNode].cost = newCost;
+                    _nodes[newNode].total = newTotal;
+
+                    // Requeue (duplicates allowed), and mark as open
+                    _openQueue.Enqueue(newNode, newTotal);
+                    _nodeStates[newNode] = 1;
+                }
+
+                if (newNode != destNode)
+                {
+                    continue;
+                }
+
+                var pathCount = 0;
+                var parent = _nodes[newNode].parent;
+
+                while (parent != -1)
+                {
+                    path[pathCount++] = GetDirection(
+                        parent % AreaSize,
+                        parent / AreaSize % AreaSize,
+                        newNode % AreaSize,
+                        newNode / AreaSize % AreaSize
+                    );
+                    newNode = parent;
+                    parent = _nodes[newNode].parent;
+
+                    if (newNode == fromNode)
+                    {
+                        break;
+                    }
+                }
+
+                var dirs = new Direction[pathCount];
+
+                while (pathCount > 0)
+                {
+                    dirs[backtrack++] = path[--pathCount];
+                }
+
+                _openQueue.Clear();
+                return dirs;
+            }
+        }
+
+        _openQueue.Clear();
+        return null;
+    }
+
+    private static int GetIndex(int x, int y, int z)
+    {
+        x -= _xOffset;
+        y -= _yOffset;
+        z += PlaneOffset;
+        z /= PlaneHeight;
+
+        return x + y * AreaSize + z * AreaSize * AreaSize;
+    }
+
+    private static int GetSuccessors(int p, Mobile m, Map map)
+    {
+        var px = p % AreaSize;
+        var py = p / AreaSize % AreaSize;
+        var pz = _nodes[p].z;
+
+        var p3D = new Point3D(px + _xOffset, py + _yOffset, pz);
+
+        var vals = _successors;
+        var count = 0;
+
+        for (var i = 0; i < 8; ++i)
+        {
+            int x;
+            int y;
+            switch (i)
+            {
+                default: // 0
+                    x = 0;
+                    y = -1;
+                    break;
+                case 1:
+                    x = 1;
+                    y = -1;
+                    break;
+                case 2:
+                    x = 1;
+                    y = 0;
+                    break;
+                case 3:
+                    x = 1;
+                    y = 1;
+                    break;
+                case 4:
+                    x = 0;
+                    y = 1;
+                    break;
+                case 5:
+                    x = -1;
+                    y = 1;
+                    break;
+                case 6:
+                    x = -1;
+                    y = 0;
+                    break;
+                case 7:
+                    x = -1;
+                    y = -1;
+                    break;
+            }
+
+            x += px;
+            y += py;
+
+            if (x is < 0 or >= AreaSize || y is < 0 or >= AreaSize)
+            {
+                continue;
+            }
+
+            if (CalcMoves.CheckMovement(m, map, p3D, (Direction)i, out var z))
+            {
+                var idx = GetIndex(x + _xOffset, y + _yOffset, z);
+
+                if (idx >= 0 && idx < NodeCount)
+                {
+                    _nodes[idx].z = z;
+                    vals[count++] = idx;
+                }
+            }
+        }
+
+        return count;
+    }
+}

--- a/Benchmarks/PathfindInGame/MaxSearchNodesBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/MaxSearchNodesBenchmarks.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using Server;
 using Server.Engines.Pathing.Cache;
-using Server.PathAlgorithms.BitmapAStar;
+using Server.PathAlgorithms;
 
 namespace PathfindInGame;
 
@@ -59,7 +59,7 @@ public class MaxSearchNodesBenchmarks
     public void Setup()
     {
         BenchmarkFixture.EnsureInitialized();
-        BitmapAStarAlgorithm.MaxSearchNodes = MaxSearchNodes;
+        BitmapAStarAlgorithm.Instance.MaxSearchNodes = MaxSearchNodes;
 
         _map = Map.Maps[1]; // Trammel
         _stub = new StubCreature();

--- a/Benchmarks/PathfindInGame/MaxSearchNodesBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/MaxSearchNodesBenchmarks.cs
@@ -1,0 +1,86 @@
+#nullable enable
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Server;
+using Server.Engines.Pathing.Cache;
+using Server.PathAlgorithms.BitmapAStar;
+
+namespace PathfindInGame;
+
+/// <summary>
+/// Sweeps the A* node-expansion budget (<see cref="BitmapAStarAlgorithm.MaxSearchNodes"/>,
+/// the "pathfinding.maxSearchNodes" shard setting) over three representative shapes, to size
+/// it without introducing perf regressions:
+///
+///   open   — short open-terrain path; A* terminates immediately when the goal is found, so
+///            this is budget-INSENSITIVE (the control: raising the budget must not slow it).
+///   detour — a walled-off goal 2 tiles away reachable only via a ~33-step route around the
+///            Britain Inn (Trammel). Needs ~500 expansions; returns NULL below that.
+///   fail   — the owner one floor up (Z+20) behind walls, unreachable within the 38-tile
+///            window. The search always runs to the FULL budget, so this is the worst-case
+///            per-Find cost — the number that bounds how high the budget can safely go.
+///
+/// Expected shape: 'open' flat across all budgets; 'detour' NULL at 300, found from ~500 up;
+/// 'fail' rising with budget then PLATEAUING (~1500) once the reachable window is exhausted.
+/// The cache is warmed in setup and kept warm (no per-iteration clear) so this isolates
+/// search cost from chunk-build cost.
+///
+/// REQUIRES the ModernUO submodule to include the `MaxSearchNodes` field (the
+/// pathfinding.maxSearchNodes change). Bump the submodule before building/running.
+/// Run e.g.:  dotnet run -c Release -- --filter '*MaxSearchNodesBenchmarks*'
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class MaxSearchNodesBenchmarks
+{
+    [Params(300, 500, 1000, 1500, 2000)]
+    public int MaxSearchNodes { get; set; }
+
+    // Trammel coordinates. Index 0 = open, 1 = detour, 2 = fail (see class summary).
+    private static readonly Point3D[] _starts =
+    {
+        new(1455, 1560, 30),
+        new(1443, 1568, 30),
+        new(1443, 1568, 30),
+    };
+
+    private static readonly Point3D[] _goals =
+    {
+        new(1449, 1560, 30),
+        new(1444, 1566, 30),
+        new(1444, 1566, 50),
+    };
+
+    private StubCreature _stub = null!;
+    private Map _map = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        BenchmarkFixture.EnsureInitialized();
+        BitmapAStarAlgorithm.MaxSearchNodes = MaxSearchNodes;
+
+        _map = Map.Maps[1]; // Trammel
+        _stub = new StubCreature();
+        _stub.MoveToWorld(_starts[0], _map);
+
+        // Steady-state warm cache: prime the chunks each route touches so the measured Find
+        // pays only search cost, not first-touch BuildChunk cost.
+        StepCache.Instance.CloseLazyReaders();
+        for (var i = 0; i < _starts.Length; i++)
+        {
+            for (var w = 0; w < 5; w++)
+            {
+                BitmapAStarAlgorithm.Instance.Find(_stub, _map, _starts[i], _goals[i]);
+            }
+        }
+    }
+
+    [Benchmark]
+    [Arguments(0)] // open   (control: budget-insensitive)
+    [Arguments(1)] // detour (~33-step indoor route; NULL until budget >= ~500)
+    [Arguments(2)] // fail   (unreachable; runs to full budget = worst case)
+    public Direction[]? Find(int scenario) =>
+        BitmapAStarAlgorithm.Instance.Find(_stub, _map, _starts[scenario], _goals[scenario]);
+}

--- a/Benchmarks/PathfindInGame/PathfindBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/PathfindBenchmarks.cs
@@ -7,6 +7,7 @@ using BenchmarkDotNet.Jobs;
 using Server;
 using Server.Engines.Pathing.Cache;
 using Server.PathAlgorithms.BitmapAStar;
+using Server.PathAlgorithms.FastAStar;
 
 namespace PathfindInGame;
 
@@ -135,6 +136,24 @@ public class PathfindBenchmarks
         var s = _staticScenarios[scenarioIndex];
         var stub = _stubMobiles[scenarioIndex];
         return BitmapAStarAlgorithm.Instance.Find(stub, s.ResolveMap(), s.Start, s.Goal);
+    }
+
+    /// <summary>
+    /// Pre-cache baseline: the FastAStarAlgorithm that ModernUO shipped before the
+    /// step-cache rework (snapshot at e1e1a7c640). Pulled in directly so the bench can
+    /// produce apples-to-apples comparison numbers without checking out an old branch.
+    /// FastAStar is cache-agnostic, so the Provider param has no effect on its results
+    /// — every Provider variant produces ~the same number for this method. Filter to a
+    /// single Provider if you want a clean row per scenario, e.g.:
+    ///   --filter '*FastAStar_Find*Provider=Cold*'
+    /// </summary>
+    [Benchmark]
+    [ArgumentsSource(nameof(ScenarioIndices))]
+    public Direction[]? FastAStar_Find(int scenarioIndex)
+    {
+        var s = _staticScenarios[scenarioIndex];
+        var stub = _stubMobiles[scenarioIndex];
+        return FastAStarAlgorithm.Instance.Find(stub, s.ResolveMap(), s.Start, s.Goal);
     }
 
     public System.Collections.Generic.IEnumerable<int> ScenarioIndices()

--- a/Benchmarks/PathfindInGame/PathfindBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/PathfindBenchmarks.cs
@@ -147,7 +147,7 @@ public class PathfindBenchmarks
     /// single Provider if you want a clean row per scenario, e.g.:
     ///   --filter '*FastAStar_Find*Provider=Cold*'
     /// </summary>
-    [Benchmark]
+    [Benchmark(Baseline = true)]
     [ArgumentsSource(nameof(ScenarioIndices))]
     public Direction[]? FastAStar_Find(int scenarioIndex)
     {

--- a/Benchmarks/PathfindInGame/PathfindBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/PathfindBenchmarks.cs
@@ -6,7 +6,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using Server;
 using Server.Engines.Pathing.Cache;
-using Server.PathAlgorithms.BitmapAStar;
+using Server.PathAlgorithms;
 using Server.PathAlgorithms.FastAStar;
 
 namespace PathfindInGame;
@@ -79,9 +79,73 @@ public class PathfindBenchmarks
 
         StepCache.Instance.CloseLazyReaders();
 
+        ReportCorpusHealthOnce();
+
         if (Provider is PathProvider.LazyCold or PathProvider.LazyWarm)
         {
             OpenLazyReadersForCorpus();
+        }
+    }
+
+    private static bool _healthReported;
+
+    /// <summary>
+    /// One-time corpus audit (prints to stderr, not measured). Hand-authored scenarios drift:
+    /// an endpoint Z can land over water or inside a wall, producing a degenerate "no path"
+    /// search whose timing is meaningless. For each scenario this runs one warm Find with the
+    /// real creature flags and reports whether a path was found and the cache fallthrough
+    /// fraction, so a glance at the log shows which rows to trust. SUSPECT = no path (bad
+    /// coords/Z); high fallthrough = the cache can't serve the route (e.g. off-surface Z).
+    /// </summary>
+    private void ReportCorpusHealthOnce()
+    {
+        if (_healthReported)
+        {
+            return;
+        }
+        _healthReported = true;
+
+        var cache = StepCache.Instance;
+        var previousThreshold = cache.MissPromotionThreshold;
+        cache.MissPromotionThreshold = 1; // eager build — judge the cache's best case
+
+        try
+        {
+            Console.Error.WriteLine("[CorpusHealth] idx scenario                          result      cacheFallthrough");
+            for (var i = 0; i < _staticScenarios.Length; i++)
+            {
+                var s = _staticScenarios[i];
+                var stub = _stubMobiles[i];
+                var map = s.ResolveMap();
+
+                for (var w = 0; w < 3; w++)
+                {
+                    BitmapAStarAlgorithm.Instance.Find(stub, map, s.Start, s.Goal);
+                }
+
+                var before = cache.GetStats();
+                var path = BitmapAStarAlgorithm.Instance.Find(stub, map, s.Start, s.Goal);
+                var after = cache.GetStats();
+
+                var served = after.Hits - before.Hits
+                             + (after.MissesNotBuilt - before.MissesNotBuilt)
+                             + (after.MissesDirtyRebuild - before.MissesDirtyRebuild);
+                var fallthrough = after.FallthroughMultiZ - before.FallthroughMultiZ
+                                  + (after.FallthroughSourceZMismatch - before.FallthroughSourceZMismatch)
+                                  + (after.FallthroughOffMap - before.FallthroughOffMap)
+                                  + (after.FallthroughNotBuilt - before.FallthroughNotBuilt);
+                var total = served + fallthrough;
+                var pct = total == 0 ? 0 : 100.0 * fallthrough / total;
+
+                var result = path == null ? "NO PATH" : $"{path.Length} steps";
+                var flag = path == null ? "  <-- SUSPECT (bad coords/Z?)" : pct > 50 ? "  <-- high fallthrough" : "";
+                Console.Error.WriteLine($"[CorpusHealth] [{i,2}] {s.Name,-34} {result,-11} {pct,5:F1}%{flag}");
+            }
+        }
+        finally
+        {
+            cache.MissPromotionThreshold = previousThreshold;
+            cache.ClearResidentChunks();
         }
     }
 

--- a/Benchmarks/PathfindInGame/PathfindBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/PathfindBenchmarks.cs
@@ -15,14 +15,23 @@ namespace PathfindInGame;
 public class PathfindBenchmarks
 {
     /// <summary>
-    /// Three production-relevant variants:
+    /// Four production-relevant variants:
     ///
-    ///   Cold         — no .swb file open, cache cleared each iteration. Reference
-    ///                  baseline showing the runtime-baker-only cost an operator gets
-    ///                  if no .swb files have been baked.
+    ///   Cold         — no .swb file open, cache cleared each iteration. Pessimistic:
+    ///                  every iteration pays the full BuildChunk cost. Models a "first
+    ///                  pathfind ever in this region" event, not steady-state — a real
+    ///                  hobby admin without baked files only sees this for the FIRST
+    ///                  pathfind in each region per server lifetime.
+    ///   WarmNoFile   — no .swb file open, cache kept warm across iterations. The
+    ///                  realistic hobby-admin workload: no .swb files, but BDN warmup
+    ///                  populates the chunks once via the runtime baker; measurement
+    ///                  iterations all hit the warm cache. After warmup, this should
+    ///                  match LazyWarm — the .swb file's only job is to make the FIRST
+    ///                  pathfind cheaper, not the steady state.
     ///   LazyCold     — .swb files opened as lazy backing stores in [GlobalSetup],
     ///                  cache cleared each iteration. Measures "first pathfind through
-    ///                  a region after boot" — chunks reload from file, not from baker.
+    ///                  a region after boot" with a baked file present — chunks reload
+    ///                  from file, not from baker.
     ///   LazyWarm     — .swb files opened, cache kept warm across iterations. Production
     ///                  steady-state shape: file-loaded chunks resident, lowest mean
     ///                  per-call latency we ship.
@@ -30,6 +39,7 @@ public class PathfindBenchmarks
     public enum PathProvider
     {
         Cold,
+        WarmNoFile,
         LazyCold,
         LazyWarm,
     }
@@ -108,13 +118,12 @@ public class PathfindBenchmarks
     [IterationSetup]
     public void IterationSetup()
     {
-        // Cold variants clear chunks every iteration so we measure first-pathfind cost.
-        // In Cold the runtime baker rebuilds chunks; in LazyCold the chunk-miss resolves
-        // from the open .swb file. LazyWarm keeps everything resident — production
-        // steady-state shape.
+        // Cold/LazyCold clear residents so every iteration measures first-pathfind cost
+        // from baker / file respectively. WarmNoFile and LazyWarm keep the cache warm
+        // across iterations — measurement iterations land on cache hits after BDN's
+        // warmup populates the chunks.
         if (Provider is PathProvider.Cold or PathProvider.LazyCold)
         {
-            // Clear residents but keep the lazy readers open.
             StepCache.Instance.ClearResidentChunks();
         }
     }

--- a/Benchmarks/PathfindInGame/PathfindBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/PathfindBenchmarks.cs
@@ -1,0 +1,138 @@
+#nullable enable
+
+using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Server;
+using Server.Engines.Pathing.Cache;
+using Server.PathAlgorithms.BitmapAStar;
+
+namespace PathfindInGame;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class PathfindBenchmarks
+{
+    /// <summary>
+    /// Three production-relevant variants:
+    ///
+    ///   Cold         — no .swb file open, cache cleared each iteration. Reference
+    ///                  baseline showing the runtime-baker-only cost an operator gets
+    ///                  if no .swb files have been baked.
+    ///   LazyCold     — .swb files opened as lazy backing stores in [GlobalSetup],
+    ///                  cache cleared each iteration. Measures "first pathfind through
+    ///                  a region after boot" — chunks reload from file, not from baker.
+    ///   LazyWarm     — .swb files opened, cache kept warm across iterations. Production
+    ///                  steady-state shape: file-loaded chunks resident, lowest mean
+    ///                  per-call latency we ship.
+    /// </summary>
+    public enum PathProvider
+    {
+        Cold,
+        LazyCold,
+        LazyWarm,
+    }
+
+    [ParamsAllValues]
+    public PathProvider Provider { get; set; }
+
+    private static readonly PathfindScenario[] _staticScenarios = LoadCorpus();
+
+    private StubCreature[] _stubMobiles = null!;
+
+    private static PathfindScenario[] LoadCorpus()
+    {
+        var corpusPath = Path.Combine(AppContext.BaseDirectory, "Corpus", "baseline.jsonl");
+        return ScenarioCorpus.LoadJsonl(corpusPath);
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        BenchmarkFixture.EnsureInitialized();
+
+        _stubMobiles = new StubCreature[_staticScenarios.Length];
+        for (var i = 0; i < _staticScenarios.Length; i++)
+        {
+            var s = _staticScenarios[i];
+            var stub = new StubCreature
+            {
+                CanSwim = s.CanSwim,
+                CantWalk = false
+            };
+            stub.SetMobilityFlags(s.CanOpenDoors, s.CanMoveOverObstacles);
+            stub.MoveToWorld(s.Start, s.ResolveMap());
+            _stubMobiles[i] = stub;
+        }
+
+        StepCache.Instance.CloseLazyReaders();
+
+        if (Provider is PathProvider.LazyCold or PathProvider.LazyWarm)
+        {
+            OpenLazyReadersForCorpus();
+        }
+    }
+
+    /// <summary>
+    /// Open the pre-baked &lt;mapId&gt;.swb files for every map referenced by the corpus
+    /// as lazy backing stores. The fixture has already invoked the baker if any file was
+    /// missing or stale (see BenchmarkFixture.EnsureBakedFiles).
+    /// </summary>
+    private static void OpenLazyReadersForCorpus()
+    {
+        var dir = BenchmarkFixture.ResolvePathfindingDataDir();
+        var loaded = new System.Collections.Generic.HashSet<int>();
+        foreach (var s in _staticScenarios)
+        {
+            if (!loaded.Add(s.MapId))
+            {
+                continue;
+            }
+            var path = Path.Combine(dir, $"{s.MapId}.swb");
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException(
+                    $"Precomputed cache file missing for map {s.MapId} (scenario '{s.Name}'): {path}"
+                );
+            }
+            if (!StepCache.Instance.TryOpenLazyReader(path, s.MapId))
+            {
+                throw new InvalidDataException(
+                    $"StepCache.TryOpenLazyReader rejected {path} (bad magic, version, or stale TileDataHash)"
+                );
+            }
+        }
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        // Cold variants clear chunks every iteration so we measure first-pathfind cost.
+        // In Cold the runtime baker rebuilds chunks; in LazyCold the chunk-miss resolves
+        // from the open .swb file. LazyWarm keeps everything resident — production
+        // steady-state shape.
+        if (Provider is PathProvider.Cold or PathProvider.LazyCold)
+        {
+            // Clear residents but keep the lazy readers open.
+            StepCache.Instance.ClearResidentChunks();
+        }
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(ScenarioIndices))]
+    public Direction[]? BitmapAStar_Find(int scenarioIndex)
+    {
+        var s = _staticScenarios[scenarioIndex];
+        var stub = _stubMobiles[scenarioIndex];
+        return BitmapAStarAlgorithm.Instance.Find(stub, s.ResolveMap(), s.Start, s.Goal);
+    }
+
+    public System.Collections.Generic.IEnumerable<int> ScenarioIndices()
+    {
+        for (var i = 0; i < _staticScenarios.Length; i++)
+        {
+            yield return i;
+        }
+    }
+}

--- a/Benchmarks/PathfindInGame/PathfindInGame.csproj
+++ b/Benchmarks/PathfindInGame/PathfindInGame.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <RootNamespace>PathfindInGame</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\ModernUO\Projects\Server\Server.csproj" />
+        <ProjectReference Include="..\..\ModernUO\Projects\UOContent\UOContent.csproj" />
+        <DataFiles Include="..\..\ModernUO\Distribution\Data\**" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="Corpus\baseline.jsonl">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+    <Target Name="CopyData" AfterTargets="AfterBuild">
+        <Copy SourceFiles="@(DataFiles)" DestinationFolder="$(OutDir)\Data\%(RecursiveDir)" />
+    </Target>
+</Project>

--- a/Benchmarks/PathfindInGame/PathfindScenario.cs
+++ b/Benchmarks/PathfindInGame/PathfindScenario.cs
@@ -1,0 +1,23 @@
+using Server;
+
+namespace PathfindInGame;
+
+public sealed record PathfindScenario(
+    string Name,
+    int MapId,
+    int StartX,
+    int StartY,
+    int StartZ,
+    int GoalX,
+    int GoalY,
+    int GoalZ,
+    bool CanSwim,
+    bool CanFly,
+    bool CanOpenDoors,
+    bool CanMoveOverObstacles
+)
+{
+    public Point3D Start => new(StartX, StartY, StartZ);
+    public Point3D Goal => new(GoalX, GoalY, GoalZ);
+    public Map ResolveMap() => Map.Maps[MapId];
+}

--- a/Benchmarks/PathfindInGame/Program.cs
+++ b/Benchmarks/PathfindInGame/Program.cs
@@ -1,4 +1,8 @@
+using System;
+using System.IO;
 using BenchmarkDotNet.Running;
+using Server.Engines.Pathing.Cache;
+using Server.PathAlgorithms;
 
 namespace PathfindInGame;
 
@@ -6,6 +10,66 @@ public static class Program
 {
     public static void Main(string[] args)
     {
+        // `dotnet run ... -- validate` runs a fast corpus health check (no BenchmarkDotNet
+        // measurement cycle): for each scenario it runs one warm Find with the real creature
+        // flags and prints whether a path was found and the cache fallthrough fraction. Use
+        // this to confirm corpus coordinates produce real paths before trusting the numbers.
+        if (args.Length > 0 && string.Equals(args[0], "validate", StringComparison.OrdinalIgnoreCase))
+        {
+            Validate();
+            return;
+        }
+
         BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+
+    private static void Validate()
+    {
+        BenchmarkFixture.EnsureInitialized();
+
+        var corpusPath = Path.Combine(AppContext.BaseDirectory, "Corpus", "baseline.jsonl");
+        var scenarios = ScenarioCorpus.LoadJsonl(corpusPath);
+
+        var cache = StepCache.Instance;
+        cache.MissPromotionThreshold = 1; // eager build — judge the cache's best case
+
+        Console.WriteLine($"Corpus health: {scenarios.Length} scenarios from {corpusPath}");
+        Console.WriteLine("idx scenario                           result       cacheFallthrough");
+
+        for (var i = 0; i < scenarios.Length; i++)
+        {
+            var s = scenarios[i];
+            var map = s.ResolveMap();
+
+            var stub = new StubCreature { CanSwim = s.CanSwim, CantWalk = false };
+            stub.SetMobilityFlags(s.CanOpenDoors, s.CanMoveOverObstacles);
+            stub.MoveToWorld(s.Start, map);
+
+            for (var w = 0; w < 3; w++)
+            {
+                BitmapAStarAlgorithm.Instance.Find(stub, map, s.Start, s.Goal);
+            }
+
+            var before = cache.GetStats();
+            var path = BitmapAStarAlgorithm.Instance.Find(stub, map, s.Start, s.Goal);
+            var after = cache.GetStats();
+
+            var served = after.Hits - before.Hits
+                         + (after.MissesNotBuilt - before.MissesNotBuilt)
+                         + (after.MissesDirtyRebuild - before.MissesDirtyRebuild);
+            var fallthrough = after.FallthroughMultiZ - before.FallthroughMultiZ
+                              + (after.FallthroughSourceZMismatch - before.FallthroughSourceZMismatch)
+                              + (after.FallthroughOffMap - before.FallthroughOffMap)
+                              + (after.FallthroughNotBuilt - before.FallthroughNotBuilt);
+            var total = served + fallthrough;
+            var pct = total == 0 ? 0 : 100.0 * fallthrough / total;
+
+            var result = path == null ? "NO PATH" : $"{path.Length} steps";
+            var flag = path == null ? "  <-- SUSPECT (bad coords/Z?)" : pct > 50 ? "  <-- high fallthrough" : "";
+            Console.WriteLine($"[{i,2}] {s.Name,-34} {result,-12} {pct,5:F1}%{flag}");
+
+            cache.ClearResidentChunks();
+            stub.Delete();
+        }
     }
 }

--- a/Benchmarks/PathfindInGame/Program.cs
+++ b/Benchmarks/PathfindInGame/Program.cs
@@ -1,0 +1,11 @@
+using BenchmarkDotNet.Running;
+
+namespace PathfindInGame;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/Benchmarks/PathfindInGame/README.md
+++ b/Benchmarks/PathfindInGame/README.md
@@ -1,0 +1,186 @@
+# PathfindInGame benchmarks
+
+End-to-end pathfinding benchmark for ModernUO. Boots the full UOContent
+fixture (real `Map`/`TileMatrix`/`World` state, real `.mul` tile data) and
+measures `BitmapAStarAlgorithm.Instance.Find` against a JSONL scenario corpus.
+
+This benchmark complements the sibling `NPCPathing/` benchmark (which measures
+A\* node-management cost in isolation against a synthetic always-walkable grid)
+by exercising the per-cell static walkability cache and the production
+`MovementImpl.Check` slow path. Cells with multi-Z surfaces, source-Z
+mismatches, multis, items, mobiles, and z-collision all participate exactly
+as they would on a live shard.
+
+## Submodule prerequisite
+
+The `ModernUO/` submodule pins to a SHA on the `feat/ai-pathfinding-optimization`
+branch. Until that branch merges upstream, you'll need either write access to
+`modernuo/ModernUO.git` (push the branch) or a fork URL configured in
+`.gitmodules`. `git submodule update --init` will fail with "remote ref does
+not exist" otherwise.
+
+## Running
+
+From the repo root:
+
+```
+dotnet run --project Benchmarks/PathfindInGame/PathfindInGame.csproj -c Release -- --filter "*"
+```
+
+Quick smoke (a single iteration, no statistics):
+
+```
+dotnet run --project Benchmarks/PathfindInGame/PathfindInGame.csproj -c Release -- --filter "*" --job dry
+```
+
+Results land in `BenchmarkDotNet.Artifacts/`.
+
+## First-run auto-bake
+
+The bench fixture (`BenchmarkFixture.EnsureWalkabilityCacheBaked`) checks
+that each map referenced by the corpus has a fresh `<mapId>.swb` file with a
+matching tile-data hash. If the file is missing, stale, or malformed, the
+fixture calls `Server.Engines.Pathing.Cache.WalkabilityCacheBaker.BakeMap`
+in-process. First run takes ~15 s per map; subsequent runs reuse the cache
+file and start instantly.
+
+Override the cache directory with `MODERNUO_PATHFINDING_DATA_DIR`. Override
+the UO client data with `MODERNUO_TEST_DATA_DIR` (defaults to
+`C:\Ultima Online Classic` on Windows).
+
+## Scenario corpus
+
+`Corpus/baseline.jsonl` — five hand-picked Trammel scenarios covering the
+production cost surface:
+
+| Idx | Name | Path | Why |
+|-----|------|------|-----|
+| 0 | trammel_open_plain | (1496,1628,10) → (1530,1660,10) | Long open-terrain path; cache hits dominate |
+| 1 | trammel_dense_forest_yew | (585,845,0) → (615,875,0) | Tier 2 chunks with obstacle statics (trees) |
+| 2 | trammel_corridor_brit_sewer | (1418,1696,-32) → (1450,1720,-32) | Tight corridor with stairs, dense multi-Z |
+| 3 | trammel_multifloor_brit_inn | (1494,1626,20) → (1502,1632,20) | Multi-floor inn — exercises Tier 4 strata |
+| 4 | trammel_britain_causeway | (1478,1647,0) → (1502,1647,0) | Causeway over courtyard — multi-Z paver region |
+
+Add scenarios by appending lines to `baseline.jsonl`. To capture real
+production scenarios, use the in-server `[PathRecord on` admin command;
+output goes to `<server-base>/pathfinds.jsonl`.
+
+## Provider matrix
+
+`PathProvider` enumerates the production-relevant cache configurations:
+
+- **`Cold`** — no `.swb` loaded, cache cleared each iteration. Reference
+  baseline showing the runtime-baker-only cost an operator gets if they
+  never run `[BuildPathingCache`. First-pathfind-after-boot worst case.
+- **`PrecomputedColdTier4`** — `.swb` loaded in `[GlobalSetup]`, cache cleared
+  each iteration. Measures "first pathfind after boot" — chunks reload from
+  the file each iteration, Tier 4 strata absorb the multi-Z / source-Z
+  fallthroughs that the runtime baker would have left as slow-path dispatches.
+- **`PrecomputedWarmTier4`** — `.swb` loaded + cache resident across
+  iterations. Production steady-state shape: file-loaded chunks resident,
+  every fallthrough absorbed by Tier 4. Lowest mean per-call latency we ship.
+
+3 providers × 5 scenarios = 15 entries.
+
+## Cumulative perf story
+
+Numbers below are `Mean` from a clean BDN run on the i9-12900K reference
+hardware. Each row shows what shipped at each milestone. Every milestone
+is a strict improvement over its predecessor for the production-shape
+column (`PrecomputedWarmTier4`); the `Cold` column drifts up because each
+milestone exposes the cache to more scenarios that the runtime baker now
+has to work for.
+
+| Milestone | S0 plain | S1 forest | S2 sewer | S3 inn | S4 causeway |
+|-----------|---------:|----------:|---------:|-------:|------------:|
+| **FastAStarAlgorithm** (no cache, baseline) | ~3,500 µs | ~4,000 µs | ~36 µs | ~2,300 µs | ~1,000 µs |
+| Cache + Tier 0/1/2/3 file | 256 µs | 257 µs | 44 µs | 2,309 µs | 16.7 µs |
+| `IsDefaultWalker` capability fix | 254 µs | 261 µs | 34 µs | 297 µs | 14.5 µs |
+| zstd compression (no perf change, -90% disk) | 254 µs | 261 µs | 34 µs | 297 µs | 14.5 µs |
+| **Tier 4 strata (current)** | **218 µs** | **209 µs** | **22 µs** | **198 µs** | **14 µs** |
+
+S3 (multi-floor inn) is the headline: dropped from 2,309 µs to 198 µs once
+Tier 4 strata absorb the per-source-Z answers that the cache previously
+couldn't model. All scenarios now sit at or below 250 µs steady-state.
+
+### Latest measured numbers (v6)
+
+```
+| Method         | Provider             | scenarioIndex |   Mean        | Allocated |
+|--------------- |--------------------- |-------------- |--------------:|----------:|
+| FastAStar_Find | Cold                 | 0             | 2,885.93 us   |   44,736 B |
+| FastAStar_Find | Cold                 | 1             | 3,387.89 us   |   67,104 B |
+| FastAStar_Find | Cold                 | 2             | 1,043.17 us   |   11,184 B |
+| FastAStar_Find | Cold                 | 3             | 3,535.03 us   |   44,736 B |
+| FastAStar_Find | Cold                 | 4             | 1,283.04 us   |   11,184 B |
+| FastAStar_Find | PrecomputedColdTier4 | 0             |   273.55 us   |   33,224 B |
+| FastAStar_Find | PrecomputedColdTier4 | 1             |   272.93 us   |   23,312 B |
+| FastAStar_Find | PrecomputedColdTier4 | 2             |    54.81 us   |    2,992 B |
+| FastAStar_Find | PrecomputedColdTier4 | 3             |   267.04 us   |   35,120 B |
+| FastAStar_Find | PrecomputedColdTier4 | 4             |    56.99 us   |    6,656 B |
+| FastAStar_Find | PrecomputedWarmTier4 | 0             |   218.23 us   |          - |
+| FastAStar_Find | PrecomputedWarmTier4 | 1             |   209.22 us   |          - |
+| FastAStar_Find | PrecomputedWarmTier4 | 2             |    22.22 us   |          - |
+| FastAStar_Find | PrecomputedWarmTier4 | 3             |   198.20 us   |          - |
+| FastAStar_Find | PrecomputedWarmTier4 | 4             |    13.82 us   |          - |
+```
+
+`PrecomputedWarmTier4` shows **zero allocations** across all scenarios — the
+production steady-state path doesn't touch the GC. `PrecomputedColdTier4`'s
+allocations come from the per-chunk `WalkabilityChunk` + `Strata` buffers
+materialised on first-touch from the file; LRU eviction reclaims them.
+
+### Per-call cost (companion `Benchmarks/StaticWalkabilityCache/`)
+
+For the per-call breakdown of cache vs slow-path cost, see the sibling
+`StaticWalkabilityCache` benchmark. Headline numbers from the same run:
+
+```
+| Method              |          Mean | Allocated |
+|-------------------- |--------------:|----------:|
+| CacheHit_Warm       |      12.08 ns |         - |  ← cache-hit hot path
+| Cache_FullRoundTrip |      14.21 ns |         - |  ← full TryGetMask incl. guards
+| MovementImpl_Direct |      66.11 ns |         - |  ← slow-path single direction
+| Baker_Direct        |     259.09 ns |         - |  ← one cell ComputeMaskAt
+| CacheHit_Cold       | 792,168.57 ns |   11,184 B|  ← Clear + first hit (chunk build)
+```
+
+A single cache hit costs **~5.5× less** than a single slow-path direction
+call. A's Find typically expands hundreds of cells per pathfind, so the
+per-call savings compound into the path-level deltas above.
+
+## Disk footprint and bake time
+
+All six facets, current format (v6 — interval-encoded Tier 4 strata):
+
+| Map | File size | Tier 3 zstd ratio |
+|-----|----------:|-------------------|
+| 0 Felucca | 9.09 MB | ~91% saved |
+| 1 Trammel | 9.11 MB | ~91% saved |
+| 2 Ilshenar | 2.06 MB | ~89% saved |
+| 3 Malas | 1.87 MB | ~92% saved |
+| 4 Tokuno | 1.08 MB | ~88% saved |
+| 5 TerMur | 2.26 MB | ~88% saved |
+| **Total** | **25.49 MB** | — |
+
+Bake time (all 6 facets, sequential): ~45 s on the reference hardware.
+
+## Hardware reference
+
+```
+BenchmarkDotNet v0.15.6, Windows 11 (10.0.26200.8246)
+12th Gen Intel Core i9-12900K 3.20GHz, 1 CPU, 24 logical and 16 physical cores
+.NET SDK 10.0.203
+  [Host]    : .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3
+  .NET 10.0 : .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3
+```
+
+When re-running on different hardware, append a new section with the
+machine info and the cumulative perf table re-captured against the same
+five scenarios.
+
+## File-format reference
+
+The `<mapId>.swb` format is documented at the top of
+`Server.Engines.Pathing.Cache.PrecomputedCacheFile`. Current version: 6.
+The bake side lives in `Server.Engines.Pathing.Cache.WalkabilityCacheBaker`.

--- a/Benchmarks/PathfindInGame/README.md
+++ b/Benchmarks/PathfindInGame/README.md
@@ -13,11 +13,9 @@ as they would on a live shard.
 
 ## Submodule prerequisite
 
-The `ModernUO/` submodule pins to a SHA on the `feat/ai-pathfinding-optimization`
-branch. Until that branch merges upstream, you'll need either write access to
-`modernuo/ModernUO.git` (push the branch) or a fork URL configured in
-`.gitmodules`. `git submodule update --init` will fail with "remote ref does
-not exist" otherwise.
+The `ModernUO/` submodule pins to a SHA on `modernuo/ModernUO` `main` (the
+pathfinding step-cache work merged upstream in #2478). `git submodule update
+--init` works against the public remote — no fork URL or write access required.
 
 ## Running
 
@@ -56,6 +54,44 @@ dotnet run --project Benchmarks/PathfindInGame/PathfindInGame.csproj -c Release 
 **Prerequisite:** the `ModernUO/` submodule must be at a commit that includes the
 `BitmapAStarAlgorithm.MaxSearchNodes` field (the `pathfinding.maxSearchNodes`
 change). Bump the submodule first, or the project won't compile.
+
+### Measured
+
+| MaxSearchNodes | open (0) | detour (1) | fail (2) | open alloc | detour alloc | fail alloc |
+|---:|--:|--:|--:|--:|--:|--:|
+| 300  |  2.10 µs |  22.1 µs |  22.3 µs | 32 B | 0 B  | 0 B  |
+| 500  |  2.16 µs |  23.2 µs |  33.5 µs | 32 B | 64 B | 0 B  |
+| 1000 |  2.17 µs |  22.5 µs |  79.4 µs | 32 B | 64 B | 0 B  |
+| 1500 |  4.27 µs* | 45.2 µs* | 183.8 µs* | 32 B | 64 B | 72 B |
+| 2000 |  4.44 µs* | 44.8 µs* | 186.8 µs* | 32 B | 64 B | 72 B |
+
+\* The 1500/2000 rows are ~2× inflated by thermal/clock drift during the later
+`[Params]` runs — the `open` control is budget-invariant by construction yet
+doubled, so discount that whole column ~2× (or re-run those two params isolated).
+
+**Conclusions:**
+
+- **`open` is budget-insensitive** (~2 µs) — the cap never touches the common case;
+  successful searches terminate on goal-found.
+- **`detour` needs ≥ 500** to navigate the ~33-step walled-off indoor route; at 300
+  it bails and returns `null`. Default 1000 gives 2× margin.
+- **`fail` (unreachable) cost rises then plateaus** at window-exhaustion (~1500–1700
+  nodes). At 1000 the worst-case failed search is ~79 µs because it bails *before*
+  exhausting; pushing to 1500+ raises it to the ~185 µs (≈ ~90 µs de-thermalled)
+  plateau for **zero** solving benefit. So **1000 is near-optimal** — above the
+  ~500 needed to solve indoor routes, below the window-exhaustion cost ceiling.
+
+**Allocation note.** The only *intentional* allocation in `Find` is the returned
+`Direction[]` path (`open` ~6 steps → 32 B, `detour` ~33 steps → 64 B; `detour@300`
+= 0 B because it returns `null`). The internal A\* buffers (`_nodes`, `_nodeStates`,
+`_path`, `_openQueue`) are `static` singletons — zero-alloc. The search loop itself
+is zero-alloc: a single warm *failing* `Find` allocates 0 B at every budget
+(300→3000), verified with `GC.GetAllocatedBytesForCurrentThread`. The surprising
+`fail` 72 B at ≥ 1500 is therefore **not** a result array (that scenario returns
+`null` at all budgets) and **not** the search loop — it's an incidental cache
+first-touch (a peripheral `WalkabilityChunk`/strata materialized when the failing
+search runs to the window edge, only reached at high budget). Tiny and transient;
+it's one more reason to keep the budget modest.
 
 ## First-run auto-bake
 
@@ -152,24 +188,14 @@ production steady-state path doesn't touch the GC. `PrecomputedColdTier4`'s
 allocations come from the per-chunk `WalkabilityChunk` + `Strata` buffers
 materialised on first-touch from the file; LRU eviction reclaims them.
 
-### Per-call cost (companion `Benchmarks/StaticWalkabilityCache/`)
+### Per-call cost
 
-For the per-call breakdown of cache vs slow-path cost, see the sibling
-`StaticWalkabilityCache` benchmark. Headline numbers from the same run:
-
-```
-| Method              |          Mean | Allocated |
-|-------------------- |--------------:|----------:|
-| CacheHit_Warm       |      12.08 ns |         - |  ← cache-hit hot path
-| Cache_FullRoundTrip |      14.21 ns |         - |  ← full TryGetMask incl. guards
-| MovementImpl_Direct |      66.11 ns |         - |  ← slow-path single direction
-| Baker_Direct        |     259.09 ns |         - |  ← one cell ComputeMaskAt
-| CacheHit_Cold       | 792,168.57 ns |   11,184 B|  ← Clear + first hit (chunk build)
-```
-
-A single cache hit costs **~5.5× less** than a single slow-path direction
-call. A's Find typically expands hundreds of cells per pathfind, so the
-per-call savings compound into the path-level deltas above.
+The companion per-call micro-benchmark (`StaticWalkabilityCache`) has been
+removed; its cache-vs-slow-path breakdown is superseded by the end-to-end
+numbers above. A single warm cache hit is roughly an order of magnitude cheaper
+than a slow-path `MovementImpl.Check` direction call, and A*'s `Find` expands
+hundreds of cells per pathfind, so the per-call savings compound into the
+path-level deltas.
 
 ## Disk footprint and bake time
 
@@ -204,5 +230,5 @@ five scenarios.
 ## File-format reference
 
 The `<mapId>.swb` format is documented at the top of
-`Server.Engines.Pathing.Cache.PrecomputedCacheFile`. Current version: 6.
-The bake side lives in `Server.Engines.Pathing.Cache.WalkabilityCacheBaker`.
+`Server.Engines.Pathing.Cache.StepCacheFile`. The bake side lives in
+`Server.Engines.Pathing.Cache.StepCache.BakeMap`.

--- a/Benchmarks/PathfindInGame/README.md
+++ b/Benchmarks/PathfindInGame/README.md
@@ -35,6 +35,28 @@ dotnet run --project Benchmarks/PathfindInGame/PathfindInGame.csproj -c Release 
 
 Results land in `BenchmarkDotNet.Artifacts/`.
 
+## MaxSearchNodes sweep
+
+`MaxSearchNodesBenchmarks` sweeps the A\* node-expansion budget
+(`BitmapAStarAlgorithm.MaxSearchNodes`, the `pathfinding.maxSearchNodes` shard
+setting, default 1000) over three shapes to size it without perf regressions:
+
+- **open** — short open-terrain path; A\* terminates on goal-found, so this is
+  budget-insensitive (the control — raising the budget must not slow it).
+- **detour** — a ~33-step walled-off route around the Britain Inn; returns NULL
+  below ~500 expansions, found above it.
+- **fail** — an unreachable upstairs goal; the search runs to the full budget, so
+  this is the worst-case per-`Find` cost. Rises with budget then plateaus (~1500)
+  once the 38-tile window is exhausted.
+
+```
+dotnet run --project Benchmarks/PathfindInGame/PathfindInGame.csproj -c Release -- --filter "*MaxSearchNodesBenchmarks*"
+```
+
+**Prerequisite:** the `ModernUO/` submodule must be at a commit that includes the
+`BitmapAStarAlgorithm.MaxSearchNodes` field (the `pathfinding.maxSearchNodes`
+change). Bump the submodule first, or the project won't compile.
+
 ## First-run auto-bake
 
 The bench fixture (`BenchmarkFixture.EnsureWalkabilityCacheBaked`) checks

--- a/Benchmarks/PathfindInGame/ScenarioCorpus.cs
+++ b/Benchmarks/PathfindInGame/ScenarioCorpus.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace PathfindInGame;
+
+public static class ScenarioCorpus
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static PathfindScenario[] LoadJsonl(string path)
+    {
+        var scenarios = new List<PathfindScenario>();
+
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            var scenario = JsonSerializer.Deserialize<PathfindScenario>(line, _jsonOptions);
+            if (scenario != null)
+            {
+                scenarios.Add(scenario);
+            }
+        }
+
+        return scenarios.ToArray();
+    }
+}

--- a/Benchmarks/PathfindInGame/StubCreature.cs
+++ b/Benchmarks/PathfindInGame/StubCreature.cs
@@ -1,0 +1,35 @@
+using ModernUO.Serialization;
+using Server;
+using Server.Mobiles;
+
+namespace PathfindInGame;
+
+[SerializationGenerator(0)]
+public sealed partial class StubCreature : BaseCreature
+{
+    private bool _canOpenDoors;
+    private bool _canMoveOverObstacles;
+
+    [Constructible]
+    public StubCreature() : base(AIType.AI_Animal, FightMode.None, 10, 1)
+    {
+        Name = "benchmark stub";
+        Body = 0xC9;
+    }
+
+    public override bool CanOpenDoors
+    {
+        get => _canOpenDoors;
+    }
+
+    public override bool CanMoveOverObstacles
+    {
+        get => _canMoveOverObstacles;
+    }
+
+    public void SetMobilityFlags(bool canOpenDoors, bool canMoveOverObstacles)
+    {
+        _canOpenDoors = canOpenDoors;
+        _canMoveOverObstacles = canMoveOverObstacles;
+    }
+}

--- a/Benchmarks/PathfindInGame/TestMapDefinitions.cs
+++ b/Benchmarks/PathfindInGame/TestMapDefinitions.cs
@@ -1,0 +1,33 @@
+namespace Server.Tests.Maps;
+
+public static class TestMapDefinitions
+{
+    public static void ConfigureTestMapDefinitions()
+    {
+        RegisterMap(0, 0, 0, 7168, 4096, 4, "Felucca", MapRules.FeluccaRules);
+        RegisterMap(1, 1, 1, 7168, 4096, 0, "Trammel", MapRules.TrammelRules);
+        RegisterMap(2, 2, 2, 2304, 1600, 1, "Ilshenar", MapRules.TrammelRules);
+        RegisterMap(3, 3, 3, 2560, 2048, 1, "Malas", MapRules.TrammelRules);
+        RegisterMap(4, 4, 4, 1448, 1448, 1, "Tokuno", MapRules.TrammelRules);
+        RegisterMap(5, 5, 5, 1280, 4096, 1, "TerMur", MapRules.TrammelRules);
+
+        RegisterMap(0x7F, 0x7F, 0x7F, Map.SectorSize, Map.SectorSize, 1, "Internal", MapRules.Internal);
+    }
+
+    private static void RegisterMap(
+        int mapIndex,
+        int mapID,
+        int fileIndex,
+        int width,
+        int height,
+        int season,
+        string name,
+        MapRules rules
+    )
+    {
+        var newMap = new Map(mapID, mapIndex, fileIndex, width, height, season, name, rules);
+
+        Map.Maps[mapIndex] = newMap;
+        Map.AllMaps.Add(newMap);
+    }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,8 @@
         <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
         <InvariantGlobalization>true</InvariantGlobalization>
         <OutputType>Exe</OutputType>
+        <ServerGarbageCollection>true</ServerGarbageCollection>
+        <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)'=='Debug'">
         <DefineConstants>TRACE;DEBUG</DefineConstants>

--- a/ModernUOBenchmarks.sln
+++ b/ModernUOBenchmarks.sln
@@ -47,11 +47,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SortedSetVPriorityQueue", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPCPathing", "Benchmarks\NPCPathing\NPCPathing.csproj", "{EF3CC62F-781F-4AF4-9691-9C3F0D7311F8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PathfindInGame", "Benchmarks\PathfindInGame\PathfindInGame.csproj", "{90CEC26F-4FE4-46BD-AA3F-4EE67F8B2E17}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks\WeakTable", "Benchmarks\WeakTable\WeakTable.csproj", "{57F7FC04-31B4-4254-9570-5CCBD645BD1F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BitMask256", "Benchmarks\BitMask256\BitMask256.csproj", "{476CC7ED-0F1F-4B3D-9D89-56BE196E16E0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StringHandling", "Benchmarks\StringHandling\StringHandling.csproj", "{249506AF-F028-4148-B33A-63F570B96A0C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StaticWalkabilityCache", "Benchmarks\StaticWalkabilityCache\StaticWalkabilityCache.csproj", "{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -237,6 +241,14 @@ Global
 		{EF3CC62F-781F-4AF4-9691-9C3F0D7311F8}.Release|Any CPU.Build.0 = Release|x64
 		{EF3CC62F-781F-4AF4-9691-9C3F0D7311F8}.Release|x64.ActiveCfg = Release|x64
 		{EF3CC62F-781F-4AF4-9691-9C3F0D7311F8}.Release|x64.Build.0 = Release|x64
+		{90CEC26F-4FE4-46BD-AA3F-4EE67F8B2E17}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{90CEC26F-4FE4-46BD-AA3F-4EE67F8B2E17}.Debug|Any CPU.Build.0 = Debug|x64
+		{90CEC26F-4FE4-46BD-AA3F-4EE67F8B2E17}.Debug|x64.ActiveCfg = Debug|x64
+		{90CEC26F-4FE4-46BD-AA3F-4EE67F8B2E17}.Debug|x64.Build.0 = Debug|x64
+		{90CEC26F-4FE4-46BD-AA3F-4EE67F8B2E17}.Release|Any CPU.ActiveCfg = Release|x64
+		{90CEC26F-4FE4-46BD-AA3F-4EE67F8B2E17}.Release|Any CPU.Build.0 = Release|x64
+		{90CEC26F-4FE4-46BD-AA3F-4EE67F8B2E17}.Release|x64.ActiveCfg = Release|x64
+		{90CEC26F-4FE4-46BD-AA3F-4EE67F8B2E17}.Release|x64.Build.0 = Release|x64
 		{57F7FC04-31B4-4254-9570-5CCBD645BD1F}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{57F7FC04-31B4-4254-9570-5CCBD645BD1F}.Debug|Any CPU.Build.0 = Debug|x64
 		{57F7FC04-31B4-4254-9570-5CCBD645BD1F}.Debug|x64.ActiveCfg = Debug|x64
@@ -261,6 +273,14 @@ Global
 		{249506AF-F028-4148-B33A-63F570B96A0C}.Release|Any CPU.Build.0 = Release|x64
 		{249506AF-F028-4148-B33A-63F570B96A0C}.Release|x64.ActiveCfg = Release|x64
 		{249506AF-F028-4148-B33A-63F570B96A0C}.Release|x64.Build.0 = Release|x64
+		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Debug|Any CPU.Build.0 = Debug|x64
+		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Debug|x64.ActiveCfg = Debug|x64
+		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Debug|x64.Build.0 = Debug|x64
+		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Release|Any CPU.ActiveCfg = Release|x64
+		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Release|Any CPU.Build.0 = Release|x64
+		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Release|x64.ActiveCfg = Release|x64
+		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ModernUOBenchmarks.sln
+++ b/ModernUOBenchmarks.sln
@@ -49,13 +49,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPCPathing", "Benchmarks\NP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PathfindInGame", "Benchmarks\PathfindInGame\PathfindInGame.csproj", "{90CEC26F-4FE4-46BD-AA3F-4EE67F8B2E17}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks\WeakTable", "Benchmarks\WeakTable\WeakTable.csproj", "{57F7FC04-31B4-4254-9570-5CCBD645BD1F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeakTable", "Benchmarks\WeakTable\WeakTable.csproj", "{57F7FC04-31B4-4254-9570-5CCBD645BD1F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BitMask256", "Benchmarks\BitMask256\BitMask256.csproj", "{476CC7ED-0F1F-4B3D-9D89-56BE196E16E0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StringHandling", "Benchmarks\StringHandling\StringHandling.csproj", "{249506AF-F028-4148-B33A-63F570B96A0C}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StaticWalkabilityCache", "Benchmarks\StaticWalkabilityCache\StaticWalkabilityCache.csproj", "{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -273,14 +271,6 @@ Global
 		{249506AF-F028-4148-B33A-63F570B96A0C}.Release|Any CPU.Build.0 = Release|x64
 		{249506AF-F028-4148-B33A-63F570B96A0C}.Release|x64.ActiveCfg = Release|x64
 		{249506AF-F028-4148-B33A-63F570B96A0C}.Release|x64.Build.0 = Release|x64
-		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Debug|Any CPU.Build.0 = Debug|x64
-		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Debug|x64.ActiveCfg = Debug|x64
-		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Debug|x64.Build.0 = Debug|x64
-		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Release|Any CPU.ActiveCfg = Release|x64
-		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Release|Any CPU.Build.0 = Release|x64
-		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Release|x64.ActiveCfg = Release|x64
-		{E4E20093-5E8A-4FF6-A941-8E4C7B6F09D7}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## What

The `PathfindInGame` end-to-end pathfinding benchmark, **reconciled to current `modernuo/ModernUO` `main`** (submodule `9d26a44a`, which includes #2478 — pathfinding prebake + multi-fallthrough), plus the PR-6 benchmark additions developed on this branch.

## Reconcile to newest main (latest commit `0a4d308`)

Bumping the submodule `1c1fd4d9 → 9d26a44a` required adapting the harness to the post-#2478 API:

- **`BenchmarkFixture.EnsureBakedFiles`** — bake-or-open via `StepCache.TryOpenLazyReader` instead of the removed `ComputeLiveFingerprint`/`TryReadFingerprintFromFile`. Fingerprint validation now lives inside `StepCacheFile.OpenForLazy`, so "can we open it?" is the freshness check (mirrors the live `PathCacheCommands.Initialize` path).
- **Namespace** — `Server.PathAlgorithms.BitmapAStar` → `Server.PathAlgorithms` (4 files).
- **API** — `MaxSearchNodes` moved static → `Instance.MaxSearchNodes`.
- **Solution** — dropped the deleted `StaticWalkabilityCache` project (dangling `.sln` reference).
- **README** — submodule now tracks `main` (no fork / write-access needed); refreshed the removed-companion section and the file-format reference (`StepCacheFile` / `StepCache.BakeMap`).

## PR-6 benchmark additions (earlier commits on this branch)

- `CacheOffBenchmarks` — `BitmapAStar` cache-off vs the vendored `FastAStar` baseline (no-regression proof for cache-disabled shards).
- `PathfindBenchmarks` — one-time corpus-health audit flagging NO-PATH / high-fallthrough scenarios.
- NPC-perception + swim/harbor scenarios, providers, corpus + `Program` updates.

## Verification

- Full solution builds against newest main (`9d26a44a`).
- Dry-run smoke green: fixture boots, `EnsureBakedFiles` bakes/opens the `.swb`, `Find`s execute (exit 0).