### PR TITLE
Multi-pathfinding benchmark — synthesizer vs slow path (DRAFT: depends on synth branch)

### DIFF
--- a/Benchmarks/PathfindInGame/BenchMulti.cs
+++ b/Benchmarks/PathfindInGame/BenchMulti.cs
@@ -1,0 +1,17 @@
+using Server.Items;
+
+namespace PathfindInGame;
+
+/// <summary>
+/// Lightweight <see cref="BaseMulti"/> for the benchmark: places a fixed-design multi (house/boat)
+/// by itemID into the live world without the owning BaseHouse / BaseBoat machinery. Mirrors the
+/// synthesizer test suite's <c>TestMulti</c>. <c>Components</c> resolves to the shared
+/// <c>MultiData.GetComponents(itemID)</c> MCL — which is all the pathfinding path reads — so this
+/// is a faithful stand-in for the per-cell walkability the synthesizer/slow-path measures.
+/// </summary>
+public sealed class BenchMulti : BaseMulti
+{
+    public BenchMulti(int itemID) : base(itemID)
+    {
+    }
+}

--- a/Benchmarks/PathfindInGame/BenchmarkFixture.cs
+++ b/Benchmarks/PathfindInGame/BenchmarkFixture.cs
@@ -56,7 +56,16 @@ public static class BenchmarkFixture
         // and the algorithm treats everything as walkable (meaningless 86ns paths).
         ForceLoadTileData();
 
+        // Multi component data must be loaded before placing houses/boats — BaseMulti.Components
+        // resolves through MultiData.GetComponents. TileData is already force-loaded above.
+        MultiData.Configure();
+
         EnsureBakedFiles();
+
+        // Place the benchmark's houses into the live world AFTER the static .swb is baked: the bake
+        // is static-only (multis are layered at query time via Fallthrough_Multi), so placement
+        // does not affect the baked file. Gives the multi-pathfinding benchmark something to route.
+        MultiScenarios.Place(Map.Maps[MultiScenarios.MapId]);
 
         _initialized = true;
     }

--- a/Benchmarks/PathfindInGame/MultiPathfindBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/MultiPathfindBenchmarks.cs
@@ -90,7 +90,7 @@ public class MultiPathfindBenchmarks
         cache.MissPromotionThreshold = 1; // eager build so the static base serves hits, not NotBuilt
         try
         {
-            System.Console.Error.WriteLine("[MultiHealth] idx route               result          multiLocalHits");
+            System.Console.Error.WriteLine("[MultiHealth] idx route               result          liveSynth  cacheServe");
             for (var i = 0; i < _routes.Length; i++)
             {
                 for (var w = 0; w < 3; w++)
@@ -98,15 +98,18 @@ public class MultiPathfindBenchmarks
                     BitmapAStarAlgorithm.Instance.Find(_stub, _map, Start(i), Goal(i));
                 }
 
-                var before = cache.GetStats().MultiLocalHits;
+                var s0 = cache.GetStats();
                 var path = BitmapAStarAlgorithm.Instance.Find(_stub, _map, Start(i), Goal(i));
-                var hits = cache.GetStats().MultiLocalHits - before;
+                var s1 = cache.GetStats();
+                var live = s1.MultiLocalHits - s0.MultiLocalHits;
+                var served = s1.MultiMaskCacheHits - s0.MultiMaskCacheHits;
 
                 var result = path == null ? "NO PATH" : $"{path.Length} steps";
                 var flag = path == null ? "  <-- SUSPECT (coords/blocked)"
-                    : hits == 0 ? "  <-- no multi cells expanded" : "";
+                    : live + served == 0 ? "  <-- no multi cells expanded"
+                    : served == 0 ? "  <-- DIRTY (cache not serving)" : "";
                 System.Console.Error.WriteLine(
-                    $"[MultiHealth] [{i,2}] {_routes[i].Name,-18} {result,-15} {hits,8}{flag}"
+                    $"[MultiHealth] [{i,2}] {_routes[i].Name,-18} {result,-15} {live,8} {served,10}{flag}"
                 );
             }
         }

--- a/Benchmarks/PathfindInGame/MultiPathfindBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/MultiPathfindBenchmarks.cs
@@ -1,0 +1,139 @@
+#nullable enable
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Server;
+using Server.Engines.Pathing.Cache;
+using Server.PathAlgorithms;
+using Server.Systems.FeatureFlags;
+
+namespace PathfindInGame;
+
+/// <summary>
+/// Measures <c>BitmapAStarAlgorithm.Find</c> over routes that weave through a dense grid of houses
+/// (see <see cref="MultiScenarios"/>), with the pathfinding cache ON vs OFF:
+///
+/// - Cache ON  → each multi-covered cell (footprint + halo) is served by the single-pass
+///   <c>ComputeMultiMaskAt</c> synthesizer (one mask build per cell).
+/// - Cache OFF → each such cell is served by the slow path's 8x per-cell <c>CheckMovement</c>.
+///
+/// The ON/OFF delta isolates the synthesizer's per-multi-cell win. REQUIRES the ModernUO submodule
+/// at the synthesizer branch (server/pathfinding-multi-tests); against plain main both arms route
+/// multi cells through the slow path and the delta collapses to ~0 (which is itself a useful
+/// baseline sanity check).
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class MultiPathfindBenchmarks
+{
+    private static readonly MultiScenarios.Route[] _routes = MultiScenarios.Routes;
+    private StubCreature _stub = null!;
+    private Map _map = null!;
+    private bool _prevFlag;
+
+    [Params(false, true)]
+    public bool CacheOn;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        BenchmarkFixture.EnsureInitialized(); // boots the world AND places the benchmark multis (once)
+
+        _prevFlag = ContentFeatureFlags.BitmapPathfindingCache;
+        ContentFeatureFlags.BitmapPathfindingCache = CacheOn;
+
+        _map = Map.Maps[MultiScenarios.MapId];
+
+        // Multi detour routes wander further than the static corpus; give A* headroom so longer
+        // weave routes resolve instead of bailing at the default budget. Applied to both arms.
+        BitmapAStarAlgorithm.Instance.MaxSearchNodes = 3000;
+
+        _stub = new StubCreature();
+        _stub.MoveToWorld(Start(0), _map);
+
+        // Warm the static chunks each route touches so the measured Find pays only search +
+        // multi-synthesis (or slow-path) cost, not first-touch BuildChunk cost. With the cache
+        // off this is a no-op probe; with it on it primes the resident static base.
+        StepCache.Instance.CloseLazyReaders();
+        for (var i = 0; i < _routes.Length; i++)
+        {
+            for (var w = 0; w < 5; w++)
+            {
+                BitmapAStarAlgorithm.Instance.Find(_stub, _map, Start(i), Goal(i));
+            }
+        }
+
+        ReportRouteHealthOnce();
+    }
+
+    private static bool _healthReported;
+
+    /// <summary>
+    /// One-time route audit (stderr, not measured). Confirms each route actually finds a path AND
+    /// expands multi-covered cells (MultiLocalHits &gt; 0) — i.e. the synthesizer is genuinely
+    /// exercised. A route that returns NO PATH or hits zero multi cells is a degenerate fixture
+    /// (bad coords / cluster fully blocks / placement off-surface) whose timing is meaningless.
+    /// </summary>
+    private void ReportRouteHealthOnce()
+    {
+        if (_healthReported)
+        {
+            return;
+        }
+        _healthReported = true;
+
+        var cache = StepCache.Instance;
+        var wasFlag = ContentFeatureFlags.BitmapPathfindingCache;
+        var wasThreshold = cache.MissPromotionThreshold;
+        ContentFeatureFlags.BitmapPathfindingCache = true;
+        cache.MissPromotionThreshold = 1; // eager build so the static base serves hits, not NotBuilt
+        try
+        {
+            System.Console.Error.WriteLine("[MultiHealth] idx route               result          multiLocalHits");
+            for (var i = 0; i < _routes.Length; i++)
+            {
+                for (var w = 0; w < 3; w++)
+                {
+                    BitmapAStarAlgorithm.Instance.Find(_stub, _map, Start(i), Goal(i));
+                }
+
+                var before = cache.GetStats().MultiLocalHits;
+                var path = BitmapAStarAlgorithm.Instance.Find(_stub, _map, Start(i), Goal(i));
+                var hits = cache.GetStats().MultiLocalHits - before;
+
+                var result = path == null ? "NO PATH" : $"{path.Length} steps";
+                var flag = path == null ? "  <-- SUSPECT (coords/blocked)"
+                    : hits == 0 ? "  <-- no multi cells expanded" : "";
+                System.Console.Error.WriteLine(
+                    $"[MultiHealth] [{i,2}] {_routes[i].Name,-18} {result,-15} {hits,8}{flag}"
+                );
+            }
+        }
+        finally
+        {
+            ContentFeatureFlags.BitmapPathfindingCache = wasFlag;
+            cache.MissPromotionThreshold = wasThreshold;
+            cache.ClearResidentChunks();
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => ContentFeatureFlags.BitmapPathfindingCache = _prevFlag;
+
+    public IEnumerable<int> RouteIndices()
+    {
+        for (var i = 0; i < _routes.Length; i++)
+        {
+            yield return i;
+        }
+    }
+
+    private Point3D Start(int i) => new(_routes[i].Sx, _routes[i].Sy, _map.GetAverageZ(_routes[i].Sx, _routes[i].Sy));
+    private Point3D Goal(int i) => new(_routes[i].Gx, _routes[i].Gy, _map.GetAverageZ(_routes[i].Gx, _routes[i].Gy));
+
+    [Benchmark]
+    [ArgumentsSource(nameof(RouteIndices))]
+    public Direction[]? MultiFind(int routeIndex) =>
+        BitmapAStarAlgorithm.Instance.Find(_stub, _map, Start(routeIndex), Goal(routeIndex));
+}

--- a/Benchmarks/PathfindInGame/MultiScenarios.cs
+++ b/Benchmarks/PathfindInGame/MultiScenarios.cs
@@ -1,0 +1,67 @@
+using Server;
+using Server.Items;
+
+namespace PathfindInGame;
+
+/// <summary>
+/// Fixed-coordinate multi (house/boat) placements and the pathfinding routes that traverse
+/// them, for the multi-pathfinding benchmark. The placements and routes are co-located so they
+/// stay in sync: <see cref="Place"/> drops the multis into the live world during fixture init,
+/// and <see cref="Routes"/> drives <c>BitmapAStarAlgorithm.Find</c> through the resulting
+/// dense multi coverage.
+///
+/// Signal: every multi-covered cell (footprint + 1-cell halo) returns <c>Fallthrough_Multi</c>
+/// and is served by the single-pass <c>ComputeMultiMaskAt</c> synthesizer when the cache is on,
+/// or by 8x per-cell <c>CheckMovement</c> when it's off. A route that weaves through a tight
+/// grid of houses maximizes the count of such expansions, so the cache-on/off delta isolates the
+/// synthesizer's per-multi-cell win.
+/// </summary>
+public static class MultiScenarios
+{
+    public const int MapId = 1;          // Trammel
+    private const int GuildHouseId = 0x74; // static house: walls, a door aperture, floor
+
+    // Open Trammel region the synthesizer's MultiPathInvariant / HousePathRouting tests use and
+    // know to be feasible. Start from a single proven house+route (validated to ~29 steps against
+    // this exact submodule code), then layer in well-separated neighbours that still leave walkable
+    // streets, so a route can weave the cluster hugging footprint halos.
+    public readonly record struct Placement(int Id, int X, int Y);
+    public readonly record struct Route(string Name, int Sx, int Sy, int Gx, int Gy);
+
+    // Three houses in a row at the proven-open y=1620 band, 20 tiles apart (wide walkable streets
+    // between footprints). A straight east-west route across them detours around each in sequence,
+    // expanding three footprints' worth of wall/halo cells the synthesizer serves.
+    public static Placement[] Placements() => new[]
+    {
+        new Placement(GuildHouseId, 1460, 1620),
+        new Placement(GuildHouseId, 1480, 1620),
+        new Placement(GuildHouseId, 1500, 1620),
+    };
+
+    // One vertical around-the-house route per placement (the MultiPathInvariantTests pattern:
+    // straight S->N through a footprint forces a side detour, ~29 steps, ~150 multi-cell synthesis
+    // calls each). Three clean single-house data points in the same proven-open band.
+    // Two feasible vertical around-the-house routes (validated: ~48 steps/246 multi-cell synthesis
+    // calls and ~29 steps/154). The eastern house's south approach is blocked by natural terrain
+    // (the search wanders into a dead end), so it's excluded — a failing search measures budget-
+    // exhaustion cost, not pathfinding cost.
+    public static readonly Route[] Routes =
+    {
+        new Route("around_w", 1460, 1630, 1460, 1610),
+        new Route("around_c", 1480, 1630, 1480, 1610),
+    };
+
+    /// <summary>
+    /// Place the benchmark multis into <paramref name="map"/>. Idempotent-ish: intended to run
+    /// exactly once from the fixture's one-time init. Requires <c>MultiData.Configure()</c> to have
+    /// run (so <c>Components</c> resolves) and the world/map sectors to be loaded.
+    /// </summary>
+    public static void Place(Map map)
+    {
+        foreach (var p in Placements())
+        {
+            var multi = new BenchMulti(p.Id);
+            multi.MoveToWorld(new Point3D(p.X, p.Y, map.GetAverageZ(p.X, p.Y)), map);
+        }
+    }
+}

--- a/Benchmarks/PathfindInGame/MultiScenarios.cs
+++ b/Benchmarks/PathfindInGame/MultiScenarios.cs
@@ -21,34 +21,26 @@ public static class MultiScenarios
     public const int MapId = 1;          // Trammel
     private const int GuildHouseId = 0x74; // static house: walls, a door aperture, floor
 
-    // Open Trammel region the synthesizer's MultiPathInvariant / HousePathRouting tests use and
-    // know to be feasible. Start from a single proven house+route (validated to ~29 steps against
-    // this exact submodule code), then layer in well-separated neighbours that still leave walkable
-    // streets, so a route can weave the cluster hugging footprint halos.
     public readonly record struct Placement(int Id, int X, int Y);
     public readonly record struct Route(string Name, int Sx, int Sy, int Gx, int Gy);
 
-    // Three houses in a row at the proven-open y=1620 band, 20 tiles apart (wide walkable streets
-    // between footprints). A straight east-west route across them detours around each in sequence,
-    // expanding three footprints' worth of wall/halo cells the synthesizer serves.
+    // Green Acres (Trammel ~5445,1153) — the flat, empty staff/test region. Houses placed here have
+    // genuinely footprint-CLEAN lots (terrain below the floor everywhere), so the Phase-3 per-instance
+    // interior cache serves — reflecting a legitimately-placed house. (The old cluttered band
+    // 1460/1480/1500,1620 overlaps tall map statics and is now correctly classified DIRTY → the cache
+    // degrades to live synthesis there, byte-identical to the slow path.)
     public static Placement[] Placements() => new[]
     {
-        new Placement(GuildHouseId, 1460, 1620),
-        new Placement(GuildHouseId, 1480, 1620),
-        new Placement(GuildHouseId, 1500, 1620),
+        new Placement(GuildHouseId, 5445, 1153),
+        new Placement(GuildHouseId, 5475, 1153),
     };
 
-    // One vertical around-the-house route per placement (the MultiPathInvariantTests pattern:
-    // straight S->N through a footprint forces a side detour, ~29 steps, ~150 multi-cell synthesis
-    // calls each). Three clean single-house data points in the same proven-open band.
-    // Two feasible vertical around-the-house routes (validated: ~48 steps/246 multi-cell synthesis
-    // calls and ~29 steps/154). The eastern house's south approach is blocked by natural terrain
-    // (the search wanders into a dead end), so it's excluded — a failing search measures budget-
-    // exhaustion cost, not pathfinding cost.
+    // Straight S->N through each footprint forces a side detour and expands the house interior, where
+    // the clean instance's interior cells serve from the per-multiID cache (~20 ns lookups).
     public static readonly Route[] Routes =
     {
-        new Route("around_w", 1460, 1630, 1460, 1610),
-        new Route("around_c", 1480, 1630, 1480, 1610),
+        new Route("around_a", 5445, 1163, 5445, 1143),
+        new Route("around_b", 5475, 1163, 5475, 1143),
     };
 
     /// <summary>

--- a/Benchmarks/PathfindInGame/MultiSynthesisMicroBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/MultiSynthesisMicroBenchmarks.cs
@@ -37,6 +37,7 @@ public class MultiSynthesisMicroBenchmarks
         Tower = 0x7A,
         Keep = 0x7C,
         Castle = 0x7E,
+        LargeBoat = 0x10, // biggest implemented ship deck — proxy for a galleon (per-cell cost is multi-type-agnostic)
     }
 
     // multiID -> placement origin. Spaced wide enough that even the Castle (~31x31) footprints
@@ -47,6 +48,7 @@ public class MultiSynthesisMicroBenchmarks
         (MultiKind.Tower, 1430, 1700),
         (MultiKind.Keep, 1480, 1700),
         (MultiKind.Castle, 1560, 1700),
+        (MultiKind.LargeBoat, 1620, 1700),
     };
 
     private static readonly Dictionary<MultiKind, BenchMulti> _placed = new();
@@ -59,7 +61,7 @@ public class MultiSynthesisMicroBenchmarks
     private sbyte _z;
     private Point3D _loc;
 
-    [Params(MultiKind.Guild, MultiKind.Tower, MultiKind.Keep, MultiKind.Castle)]
+    [Params(MultiKind.Guild, MultiKind.Tower, MultiKind.Keep, MultiKind.Castle, MultiKind.LargeBoat)]
     public MultiKind Kind;
 
     [GlobalSetup]

--- a/Benchmarks/PathfindInGame/MultiSynthesisMicroBenchmarks.cs
+++ b/Benchmarks/PathfindInGame/MultiSynthesisMicroBenchmarks.cs
@@ -1,0 +1,144 @@
+#nullable enable
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Server;
+using Server.Engines.Pathing.Cache;
+using Server.Items;
+using Server.Systems.FeatureFlags;
+using CalcMoves = Server.Movement.Movement;
+
+namespace PathfindInGame;
+
+/// <summary>
+/// Per-cell cost breakdown for multi pathfinding, across multi sizes (GuildHouse, Tower, Keep,
+/// Castle), to (a) explain the ~1.5x end-to-end win and (b) size the headroom for a "bake multi
+/// masks from multi.mul" optimization.
+///
+/// - <see cref="Synthesize_MultiCell"/> — the synthesizer's per-cell cost (one multi-aware
+///   8-direction mask build). This is exactly what a baked per-multiID mask lookup would replace.
+/// - <see cref="SlowPath8x_MultiCell"/> — the old per-cell cost (8x CheckMovement) the synthesizer
+///   replaced. The synth/slow ratio per cell drives the end-to-end win; if it grows with multi
+///   size/height (more tiles per cell → costlier CheckMovement), big multis win bigger.
+///
+/// Each multi is placed in an unused band (y=1700), away from the route benchmark's houses
+/// (y=1620). The measured cell is the FIRST covered footprint cell (scanned from the MCL), so a
+/// big multi with an open courtyard still measures a real multi cell. Requires the synthesizer
+/// submodule.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class MultiSynthesisMicroBenchmarks
+{
+    public enum MultiKind
+    {
+        Guild = 0x74,
+        Tower = 0x7A,
+        Keep = 0x7C,
+        Castle = 0x7E,
+    }
+
+    // multiID -> placement origin. Spaced wide enough that even the Castle (~31x31) footprints
+    // never overlap (so each cell measures exactly one multi's contribution).
+    private static readonly (MultiKind Kind, int X, int Y)[] _multis =
+    {
+        (MultiKind.Guild, 1400, 1700),
+        (MultiKind.Tower, 1430, 1700),
+        (MultiKind.Keep, 1480, 1700),
+        (MultiKind.Castle, 1560, 1700),
+    };
+
+    private static readonly Dictionary<MultiKind, BenchMulti> _placed = new();
+    private static bool _placedOnce;
+
+    private Map _map = null!;
+    private StubCreature _stub = null!;
+    private int _x;
+    private int _y;
+    private sbyte _z;
+    private Point3D _loc;
+
+    [Params(MultiKind.Guild, MultiKind.Tower, MultiKind.Keep, MultiKind.Castle)]
+    public MultiKind Kind;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        BenchmarkFixture.EnsureInitialized();
+        ContentFeatureFlags.BitmapPathfindingCache = true;
+        _map = Map.Maps[MultiScenarios.MapId];
+
+        if (!_placedOnce)
+        {
+            foreach (var m in _multis)
+            {
+                var multi = new BenchMulti((int)m.Kind);
+                multi.MoveToWorld(new Point3D(m.X, m.Y, _map.GetAverageZ(m.X, m.Y)), _map);
+                _placed[m.Kind] = multi;
+            }
+            _placedOnce = true;
+        }
+
+        var (cx, cy) = FirstCoveredCell(_placed[Kind]);
+        _x = cx;
+        _y = cy;
+        _z = (sbyte)_map.GetAverageZ(_x, _y);
+        _loc = new Point3D(_x, _y, _z);
+
+        _stub = new StubCreature();
+        _stub.MoveToWorld(_loc, _map);
+
+        // One-time coverage sanity to stderr: confirm the measured cell really carries multi tiles
+        // (else the synth/slow comparison would be a static-cell control, not a multi cell).
+        var mcl = _placed[Kind].Components;
+        var lx = _x - _placed[Kind].X + mcl.Center.X;
+        var ly = _y - _placed[Kind].Y + mcl.Center.Y;
+        var multiTiles = lx >= 0 && ly >= 0 && lx < mcl.Width && ly < mcl.Height ? mcl.Tiles[lx][ly].Length : 0;
+        System.Console.Error.WriteLine(
+            $"[MicroCell] {Kind} footprint {mcl.Width}x{mcl.Height} -> cell ({_x},{_y}) multiTiles={multiTiles}"
+        );
+
+        // Warm TileData / MCL resolution so the measured calls aren't paying first-touch.
+        StepProbe.ComputeMultiMaskAt(_map, _x, _y, _z);
+        for (var d = 0; d < 8; d++)
+        {
+            CalcMoves.CheckMovement(_stub, _map, _loc, (Direction)d, out _);
+        }
+    }
+
+    private static (int X, int Y) FirstCoveredCell(BaseMulti multi)
+    {
+        var mcl = multi.Components;
+        for (var ly = 0; ly < mcl.Height; ly++)
+        {
+            for (var lx = 0; lx < mcl.Width; lx++)
+            {
+                if (mcl.Tiles[lx][ly].Length > 0)
+                {
+                    return (multi.X - mcl.Center.X + lx, multi.Y - mcl.Center.Y + ly);
+                }
+            }
+        }
+        return (multi.X, multi.Y);
+    }
+
+    /// <summary>The synthesizer's whole-cell cost: one multi-aware 8-direction mask build.</summary>
+    [Benchmark]
+    public StepMask Synthesize_MultiCell() => StepProbe.ComputeMultiMaskAt(_map, _x, _y, _z);
+
+    /// <summary>The slow path's whole-cell cost the synthesizer replaced: 8x CheckMovement.</summary>
+    [Benchmark(Baseline = true)]
+    public int SlowPath8x_MultiCell()
+    {
+        var ok = 0;
+        for (var d = 0; d < 8; d++)
+        {
+            if (CalcMoves.CheckMovement(_stub, _map, _loc, (Direction)d, out _))
+            {
+                ok++;
+            }
+        }
+        return ok;
+    }
+}

--- a/Benchmarks/PathfindInGame/README.md
+++ b/Benchmarks/PathfindInGame/README.md
@@ -93,14 +93,52 @@ first-touch (a peripheral `WalkabilityChunk`/strata materialized when the failin
 search runs to the window edge, only reached at high budget). Tiny and transient;
 it's one more reason to keep the budget modest.
 
+## Multi-pathfinding (synthesizer) benchmark
+
+`MultiPathfindBenchmarks` measures `BitmapAStarAlgorithm.Find` over routes that
+detour around placed houses, with the pathfinding cache **on** vs **off**:
+
+- **Cache on** — each multi-covered cell (footprint + 1-cell halo) returns
+  `Fallthrough_Multi` and is served by the single-pass `ComputeMultiMaskAt`
+  synthesizer (one mask build per cell).
+- **Cache off** — each such cell takes the slow path's **8×** per-cell
+  `CheckMovement`.
+
+The fixture places a row of guild houses (`MultiScenarios`, via the lightweight
+`BenchMulti : BaseMulti`); the routes are validated by a one-time `[MultiHealth]`
+stderr audit that asserts each finds a path **and** expands multi cells
+(`MultiLocalHits > 0`) — a route that returns NO PATH or hits zero multi cells is
+a degenerate fixture and excluded.
+
+```
+dotnet run --project Benchmarks/PathfindInGame/PathfindInGame.csproj -c Release -- --filter "*MultiPathfindBenchmarks*"
+```
+
+**Requires the `ModernUO/` submodule at the synthesizer branch**
+(`server/pathfinding-multi-tests`). Against plain `main` both arms route multi
+cells through the slow path and the delta collapses to ~0 (a useful baseline
+sanity check, not the win).
+
+### Measured (synthesizer submodule, ShortRun warm)
+
+| Route | multi cells | Cache off (slow path) | Cache on (synthesizer) | Speedup |
+|-------|------------:|----------------------:|-----------------------:|--------:|
+| `around_w` (48 steps) | 246 | 317.9 µs | 210.5 µs | **1.51×** |
+| `around_c` (29 steps) | 154 | 205.2 µs | 141.1 µs | **1.45×** |
+
+Allocations are identical across arms (just the returned `Direction[]` path: 72 B
+/ 56 B) — the synthesizer adds no GC pressure. The win is collapsing the per-cell
+8× `CheckMovement` to a single multi-aware mask build, so it scales with the count
+of multi-covered cells a search expands.
+
 ## First-run auto-bake
 
-The bench fixture (`BenchmarkFixture.EnsureWalkabilityCacheBaked`) checks
-that each map referenced by the corpus has a fresh `<mapId>.swb` file with a
-matching tile-data hash. If the file is missing, stale, or malformed, the
-fixture calls `Server.Engines.Pathing.Cache.WalkabilityCacheBaker.BakeMap`
-in-process. First run takes ~15 s per map; subsequent runs reuse the cache
-file and start instantly.
+The bench fixture (`BenchmarkFixture.EnsureBakedFiles`) checks that each map
+referenced by the corpus has a fresh, fingerprint-valid `<mapId>.swb` file by
+trying to open it (`StepCache.TryOpenLazyReader` → `StepCacheFile.OpenForLazy`
+validates the embedded TileData fingerprint). If it can't open, the fixture bakes
+in-process via `Server.Engines.Pathing.Cache.StepCache.BakeMap`. First run takes
+~15 s per map; subsequent runs reuse the cache file and start instantly.
 
 Override the cache directory with `MODERNUO_PATHFINDING_DATA_DIR`. Override
 the UO client data with `MODERNUO_TEST_DATA_DIR` (defaults to

--- a/Benchmarks/PathfindInGame/README.md
+++ b/Benchmarks/PathfindInGame/README.md
@@ -131,6 +131,36 @@ Allocations are identical across arms (just the returned `Direction[]` path: 72 
 8× `CheckMovement` to a single multi-aware mask build, so it scales with the count
 of multi-covered cells a search expands.
 
+### Per-cell cost breakdown (`MultiSynthesisMicroBenchmarks`)
+
+Why is the end-to-end win "only" ~1.5× and not the 2–6× the static cache shows?
+Because per multi-covered cell the synthesizer is a cheaper *computation*, not a
+cached *lookup*. Per-cell, on a covered footprint cell of each multi:
+
+| Multi (footprint) | Synthesize (1 build) | Slow path (8× CheckMovement) | Per-cell speedup |
+|-------------------|---------------------:|-----------------------------:|-----------------:|
+| GuildHouse (15×15) | 737 ns | 857 ns   | 1.16× |
+| Tower (24×16)      | 783 ns | 1,139 ns | 1.45× |
+| Keep (24×24)       | 771 ns | 1,011 ns | 1.31× |
+| Castle (31×32)     | 789 ns | 1,194 ns | 1.51× |
+
+Two findings:
+
+1. **The synthesizer cost is ~flat (~780 ns) across multi sizes** — at one cell it
+   resolves only that cell's tile stack, so the multi's overall size/height doesn't
+   matter. The slow path's 8× `CheckMovement` instead **grows with multi
+   complexity** (more tiles + Z-levels per cell): Castle/Tower ~1,150–1,200 ns vs
+   GuildHouse 857 ns. So **bigger/taller multis win more** (1.16× for a guild house
+   up to 1.51× for a castle) — a route hugging a castle beats one around a cottage.
+2. **The synthesizer is the dominant cache-on cost** (~88% of a multi-heavy `Find`:
+   246 cells × ~750 ns ≈ 185 µs of the 210 µs `around_w` arm). It's still a live
+   ~780 ns compute, not a ~12 ns cache hit. **That is the headroom for baking multi
+   masks from `multi.mul`:** a baked per-`multiID` lookup would replace the ~780 ns
+   synthesis with a static-cache-style hit, lifting the multi win from ~1.5× toward
+   the static cache's 2–6×+. It applies to fixed multis (boats, classic/contest
+   houses, camps — immutable MCL in the art file); foundations (per-instance runtime
+   `DesignState`) and boundary cells still resolve live.
+
 ## First-run auto-bake
 
 The bench fixture (`BenchmarkFixture.EnsureBakedFiles`) checks that each map

--- a/Benchmarks/PathfindInGame/README.md
+++ b/Benchmarks/PathfindInGame/README.md
@@ -119,17 +119,24 @@ dotnet run --project Benchmarks/PathfindInGame/PathfindInGame.csproj -c Release 
 cells through the slow path and the delta collapses to ~0 (a useful baseline
 sanity check, not the win).
 
-### Measured (synthesizer submodule, ShortRun warm)
+### Measured
 
-| Route | multi cells | Cache off (slow path) | Cache on (synthesizer) | Speedup |
-|-------|------------:|----------------------:|-----------------------:|--------:|
-| `around_w` (48 steps) | 246 | 317.9 µs | 210.5 µs | **1.51×** |
-| `around_c` (29 steps) | 154 | 205.2 µs | 141.1 µs | **1.45×** |
+| Route | Cache off (slow path) | Phase 2 (live synth) | Phase 3 (interior cache) | Phase 3 speedup |
+|-------|----------------------:|---------------------:|-------------------------:|----------------:|
+| `around_w` (48 steps) | 308.7 µs | 210.5 µs | **132.6 µs** | **2.33×** |
+| `around_c` (29 steps) | 219.0 µs |  141.1 µs | **59.5 µs** | **3.68×** |
 
 Allocations are identical across arms (just the returned `Direction[]` path: 72 B
-/ 56 B) — the synthesizer adds no GC pressure. The win is collapsing the per-cell
-8× `CheckMovement` to a single multi-aware mask build, so it scales with the count
-of multi-covered cells a search expands.
+/ 56 B) — neither layer adds GC pressure.
+
+- **Phase 2 (live synthesizer)** collapses the per-cell 8× `CheckMovement` to one
+  multi-aware mask build (~780 ns/cell) → ~1.5×.
+- **Phase 3 (warm per-`multiID` interior cache)** turns each *interior* multi cell
+  (cell + all 8 neighbours covered → terrain-neighbour-free) into a ~20 ns cached
+  lookup. The `[MultiHealth]` audit shows the live `MultiLocalHits` dropping
+  (around_w 246→144, around_c 154→48) as ~100 interior cells/route move to the
+  cache, landing the **2–6× target** the static cache reaches. Bigger/taller
+  multis (Tower/Keep/Castle) gain most (more interior cells, costlier slow path).
 
 ### Per-cell cost breakdown (`MultiSynthesisMicroBenchmarks`)
 

--- a/Benchmarks/PathfindInGame/README.md
+++ b/Benchmarks/PathfindInGame/README.md
@@ -121,21 +121,28 @@ sanity check, not the win).
 
 ### Measured
 
-| Route | Cache off (slow path) | Phase 2 (live synth) | Phase 3 (interior cache) | Phase 3 speedup |
-|-------|----------------------:|---------------------:|-------------------------:|----------------:|
-| `around_w` (48 steps) | 308.7 µs | 210.5 µs | **132.6 µs** | **2.33×** |
-| `around_c` (29 steps) | 219.0 µs |  141.1 µs | **59.5 µs** | **3.68×** |
+Houses placed at **Green Acres** (Trammel ~5445,1153) — the flat, empty staff/test
+region — so the footprints are genuinely clean (a legitimately-placed house on a
+cleared lot), which is where the Phase-3 interior cache legitimately serves:
 
-Allocations are identical across arms (just the returned `Direction[]` path: 72 B
-/ 56 B) — neither layer adds GC pressure.
+| Route | Cache off (slow path) | Phase 3.1 (interior cache) | Speedup |
+|-------|----------------------:|---------------------------:|--------:|
+| `around_a` (29 steps, 130 cache serves) | 238.3 µs | **49.1 µs** | **4.85×** |
+| `around_b` (29 steps, 130 cache serves) | 224.3 µs | **49.5 µs** | **4.53×** |
+
+Allocations are identical across arms (just the returned `Direction[]` path: 56 B)
+— neither layer adds GC pressure.
 
 - **Phase 2 (live synthesizer)** collapses the per-cell 8× `CheckMovement` to one
   multi-aware mask build (~780 ns/cell) → ~1.5×.
-- **Phase 3 (warm per-`multiID` interior cache)** turns each *interior* multi cell
-  (cell + all 8 neighbours covered → terrain-neighbour-free) into a ~20 ns cached
-  lookup. The `[MultiHealth]` audit shows the live `MultiLocalHits` dropping
-  (around_w 246→144, around_c 154→48) as ~100 interior cells/route move to the
-  cache, landing the **2–6× target** the static cache reaches. Bigger/taller
+- **Phase 3 / 3.1 (warm per-`multiID` interior cache)** turns each *interior* multi
+  cell (cell + all 8 neighbours covered → terrain-neighbour-free) into a ~20 ns
+  cached lookup, **gated per instance on a clean footprint** (terrain below the floor
+  everywhere — airtight against cross-instance neighbour-terrain). At Green Acres the
+  `[MultiHealth]` audit shows **130 of ~167 multi cells/route served from the cache**
+  (37 live-synth perimeter), giving **~4.5–4.85×** — at or above the static cache's
+  2–6× band. A *dirty* footprint (terrain intrudes — a contrived/cluttered placement)
+  correctly degrades to live-synth, byte-identical to the slow path. Bigger/taller
   multis (Tower/Keep/Castle) gain most (more interior cells, costlier slow path).
 
 ### Per-cell cost breakdown (`MultiSynthesisMicroBenchmarks`)


### PR DESCRIPTION
## What

Adds `MultiPathfindBenchmarks` — an end-to-end multi-pathfinding benchmark measuring the single-pass multi mask synthesizer vs the slow path, on routes that detour around placed houses.

## ⚠️ Draft — depends on the synthesizer branch

The `ModernUO/` submodule is pinned to `server/pathfinding-multi-tests` (`0b1b7ebad`), **not** `main` — the cache-on arm only exercises the synthesizer there. Against plain `main` both arms route multi cells through the slow path and the delta collapses to ~0. **Do not merge until that pathfinding work lands on `main`**, then re-point the submodule to `main`.

## Harness

- `BenchmarkFixture`: configures `MultiData` and places houses (`MultiScenarios.Place`) after the static `.swb` bake (the bake is static-only, so placement doesn't affect it).
- `BenchMulti : BaseMulti` — lightweight placement type (mirrors the synthesizer suite's `TestMulti`).
- `MultiScenarios`: three guild houses in the proven-open Trammel band + two validated vertical around-the-house routes.
- One-time `[MultiHealth]` stderr audit asserts each route finds a path **and** expands multi cells (`MultiLocalHits > 0`); degenerate routes are excluded.

## Measured (synthesizer submodule, ShortRun warm)

| Route | multi cells | Cache off (slow path) | Cache on (synthesizer) | Speedup |
|-------|------------:|----------------------:|-----------------------:|--------:|
| `around_w` (48 steps) | 246 | 317.9 µs | 210.5 µs | **1.51×** |
| `around_c` (29 steps) | 154 | 205.2 µs | 141.1 µs | **1.45×** |

Identical allocations across arms (just the returned `Direction[]`). The win is collapsing the per-cell 8× `CheckMovement` to a single multi-aware mask build, so it scales with the count of multi-covered cells a search expands.